### PR TITLE
feat: its tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .artifacts
 .env
 node_modules
+native-to-anchor

--- a/lib/test_funding.js
+++ b/lib/test_funding.js
@@ -1,0 +1,68 @@
+const ethers = require("ethers");
+const fs = require("fs");
+const path = require("path");
+const utils = require("./utils");
+
+const chainsInfo = utils.getChainsInfo();
+const evmRpc = chainsInfo.chains[process.env.EVM_CHAIN].rpc;
+const evmProvider = new ethers.providers.JsonRpcProvider(evmRpc);
+const evmWallet = new ethers.Wallet(process.env.EVM_KEY, evmProvider);
+
+let wallets = [];
+
+async function mochaGlobalSetup() {
+    let files = fs.readdirSync("./test/");
+    let env = "";
+
+    for (const file of files) {
+        const baseName = path.parse(file).name;
+        const envKey = utils.toSnakeCaseCapital(baseName);
+        const wallet = ethers.Wallet.createRandom();
+
+        let tx = await evmWallet.sendTransaction({
+            to: wallet.address, value: ethers.utils.parseEther("0.2")
+        });
+
+        await tx.wait();
+
+        wallets.push(wallet.privateKey);
+
+        env += `${envKey}=${wallet.privateKey}\n`;
+    }
+
+    fs.writeFileSync("./.env.test", env);
+};
+
+async function mochaGlobalTeardown() {
+    for (const key of wallets) {
+        let wallet = new ethers.Wallet(key, evmProvider);
+
+        const balance = await wallet.getBalance();
+        const gasPrice = await evmProvider.getGasPrice();
+
+        const gasEstimation = await evmWallet.estimateGas({
+            to: evmWallet.address,
+            value: 0
+        });
+
+        const fee = gasPrice.mul(gasEstimation);
+        const valueToSend = balance.sub(fee);
+
+        let txData = {
+            to: evmWallet.address,
+            value: valueToSend,
+            gasPrice,
+            gasLimit: gasEstimation
+        };
+
+        const tx = await wallet.sendTransaction(txData);
+        await tx.wait();
+    }
+
+    fs.unlinkSync("./.env.test");
+}
+
+module.exports = {
+    mochaGlobalSetup,
+    mochaGlobalTeardown
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,17 +1,30 @@
-'use strict';
+"use strict";
 
-const anchor = require('@coral-xyz/anchor');
-const deepMerge = require('deepmerge');
-const ethers = require('ethers');
-const fs = require('fs');
-const path = require('path');
-const solanaWeb3 = require('@solana/web3.js')
+const anchor = require("@coral-xyz/anchor");
+const deepMerge = require("deepmerge");
+const ethers = require("ethers");
+const fs = require("fs");
+const path = require("path");
+const solanaWeb3 = require("@solana/web3.js");
 
-const { AxelarGMPRecoveryAPI, GMPStatus } = require('@axelar-network/axelarjs-sdk');
-const { Keypair } = solanaWeb3;
+const { AxelarGMPRecoveryAPI, GMPStatus } = require(
+    "@axelar-network/axelarjs-sdk",
+);
+const { Keypair, PublicKey } = solanaWeb3;
 const { Wallet } = anchor;
+const { createCreateMetadataAccountV3Instruction } = require(
+    "@metaplex-foundation/mpl-token-metadata",
+);
+const { createMint, getOrCreateAssociatedTokenAccount, mintTo } = require(
+    "@solana/spl-token",
+);
+const {
+    arrayify,
+    keccak256,
+    defaultAbiCoder,
+} = require("ethers/lib/utils");
 
-require('dotenv').config();
+require("dotenv").config();
 
 let chainsInfo;
 
@@ -19,30 +32,47 @@ function findProjectRoot(startDir) {
     let currentDir = startDir;
 
     while (currentDir !== path.parse(currentDir).root) {
-        const potentialPackageJson = path.join(currentDir, 'package.json');
+        const potentialPackageJson = path.join(currentDir, "package.json");
 
         if (fs.existsSync(potentialPackageJson)) {
             return currentDir;
         }
 
-        currentDir = path.resolve(currentDir, '..');
+        currentDir = path.resolve(currentDir, "..");
     }
 
-    throw new Error('Unable to find project root');
+    throw new Error("Unable to find project root");
+}
+
+function getRandomBytes32() {
+    return arrayify(keccak256(
+        defaultAbiCoder.encode(["uint256"], [
+            Math.floor(new Date().getTime() * Math.random()),
+        ]),
+    ));
 }
 
 function getChainsInfo() {
     if (chainsInfo == undefined) {
         const projectRoot = findProjectRoot(__dirname);
-        const test_contracts = JSON.parse(fs.readFileSync(path.join(projectRoot, 'test-contracts.json'), 'utf8'));
-        const amplifier_contracts = JSON.parse(fs.readFileSync(path.join(projectRoot, 'devnet-amplifier.json'), 'utf8'));
+        const test_contracts = JSON.parse(
+            fs.readFileSync(
+                path.join(projectRoot, "test-contracts.json"),
+                "utf8",
+            ),
+        );
+        const amplifier_contracts = JSON.parse(
+            fs.readFileSync(
+                path.join(projectRoot, "devnet-amplifier.json"),
+                "utf8",
+            ),
+        );
 
         chainsInfo = deepMerge(test_contracts, amplifier_contracts);
     }
 
     return chainsInfo;
 }
-
 
 function findContractPath(dir, contractName) {
     const files = fs.readdirSync(dir);
@@ -63,16 +93,16 @@ function findContractPath(dir, contractName) {
     }
 }
 
-function getContractPath(contractName, projectRoot = '') {
-    if (projectRoot === '') {
+function getContractPath(contractName, projectRoot = "") {
+    if (projectRoot === "") {
         projectRoot = findProjectRoot(__dirname);
     }
 
     projectRoot = path.resolve(projectRoot);
 
     const searchDirs = [
-        path.join(projectRoot, '.artifacts', 'evm'),
-        path.join(projectRoot, '.artifacts', 'solana'),
+        path.join(projectRoot, ".artifacts", "evm"),
+        path.join(projectRoot, ".artifacts", "solana"),
     ];
 
     for (const dir of searchDirs) {
@@ -85,14 +115,18 @@ function getContractPath(contractName, projectRoot = '') {
         }
     }
 
-    throw new Error(`Contract path for ${contractName} must be entered manually.`);
+    throw new Error(
+        `Contract path for ${contractName} must be entered manually.`,
+    );
 }
 
 function getContractJSON(contractName, artifactPath) {
     let contractPath;
 
     if (artifactPath) {
-        contractPath = artifactPath.endsWith('.json') ? artifactPath : artifactPath + contractName + '.sol/' + contractName + '.json';
+        contractPath = artifactPath.endsWith(".json")
+            ? artifactPath
+            : artifactPath + contractName + ".sol/" + contractName + ".json";
     } else {
         contractPath = getContractPath(contractName);
     }
@@ -101,12 +135,14 @@ function getContractJSON(contractName, artifactPath) {
         const contractJson = require(contractPath);
         return contractJson;
     } catch (err) {
-        throw new Error(`Failed to load contract JSON for ${contractName} at path ${contractPath} with error: ${err}`);
+        throw new Error(
+            `Failed to load contract JSON for ${contractName} at path ${contractPath} with error: ${err}`,
+        );
     }
 }
 
 async function deployEvmContract(wallet, contractName, args = []) {
-    const json = getContractJSON(contractName, '');
+    const json = getContractJSON(contractName, "");
     const factory = ethers.ContractFactory.fromSolidity(json, wallet);
     const deployment = await factory.deploy(...args);
     const contract = await deployment.deployed();
@@ -115,7 +151,7 @@ async function deployEvmContract(wallet, contractName, args = []) {
 }
 
 async function getEvmContract(wallet, contractName, address) {
-    const json = getContractJSON(contractName, '');
+    const json = getContractJSON(contractName, "");
     const factory = ethers.ContractFactory.fromSolidity(json, wallet);
 
     let contract = factory.attach(address);
@@ -128,10 +164,11 @@ async function waitForGmpExecution(txHash, axelar) {
         const subscription = axelar.subscribeToTx(txHash, (event) => {
             if (event.status == GMPStatus.DEST_EXECUTED) {
                 resolve(event);
-            } else if (event.status == GMPStatus.DEST_EXECUTE_ERROR || event.status == GMPStatus.UNKNOWN_ERROR) {
-                reject(new Error('Error executing the transaction'));
-            } else {
-                console.log('    > Received GMP status update:', event.status);
+            } else if (
+                event.status == GMPStatus.DEST_EXECUTE_ERROR ||
+                event.status == GMPStatus.UNKNOWN_ERROR
+            ) {
+                reject(new Error("Error executing the transaction"));
             }
         });
 
@@ -149,11 +186,29 @@ function setupConnections() {
     const evmWallet = new ethers.Wallet(process.env.EVM_KEY, evmProvider);
 
     const solanaRpc = chainsInfo.chains[process.env.SOLANA_CHAIN].rpc;
-    const solanaConnection = new solanaWeb3.Connection(solanaRpc, 'confirmed');
-    const solanaWallet = new Wallet(Keypair.fromSecretKey(Uint8Array.from(JSON.parse(process.env.SOLANA_KEY))));
-    const solanaProvider = new anchor.AnchorProvider(solanaConnection, solanaWallet, { commitment: 'processed' });
+    const solanaConnection = new solanaWeb3.Connection(solanaRpc, {
+        commitment: "finalized",
+        /** time to allow for the server to initially process a transaction (in milliseconds) */
+        confirmTransactionInitialTimeout: 720000,
+    });
+    const solanaWallet = new Wallet(
+        Keypair.fromSecretKey(
+            Uint8Array.from(JSON.parse(process.env.SOLANA_KEY)),
+        ),
+    );
+    const solanaProvider = new anchor.AnchorProvider(
+        solanaConnection,
+        solanaWallet,
+        { commitment: "processed" },
+    );
+    const solanaGasServiceInfo = getContractInfo(
+        "axelar_solana_gas_service",
+        process.env.SOLANA_CHAIN,
+    );
 
-    const axelar = new AxelarGMPRecoveryAPI({ environment: process.env.AXELAR_CHAIN });
+    const axelar = new AxelarGMPRecoveryAPI({
+        environment: process.env.AXELAR_CHAIN,
+    });
 
     return {
         axelar: axelar,
@@ -167,8 +222,81 @@ function setupConnections() {
             connection: solanaConnection,
             wallet: solanaWallet,
             provider: solanaProvider,
-        }
-    }
+            gasService: new PublicKey(solanaGasServiceInfo.address),
+            gasConfigPda: new PublicKey(solanaGasServiceInfo.config_pda),
+        },
+    };
+}
+
+async function setupSolanaMint(solana, name, symbol, decimals, initiaSupply) {
+    const mint = await createMint(
+        solana.connection,
+        solana.wallet.payer,
+        solana.wallet.payer.publicKey,
+        null,
+        decimals,
+    );
+
+    const associatedTokenAccount = await getOrCreateAssociatedTokenAccount(
+        solana.connection,
+        solana.wallet.payer,
+        mint,
+        solana.wallet.payer.publicKey,
+    );
+
+    await mintTo(
+        solana.connection,
+        solana.wallet.payer,
+        mint,
+        associatedTokenAccount.address,
+        solana.wallet.payer,
+        initiaSupply,
+    );
+
+    const metadataData = {
+        name,
+        symbol,
+        uri: "https://eiger.co",
+        sellerFeeBasisPoints: 0,
+        creators: null,
+        collection: null,
+        uses: null,
+    };
+    const TOKEN_METADATA_PROGRAM_ID = new PublicKey(
+        "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s",
+    );
+
+    const [metadataPda] = PublicKey.findProgramAddressSync(
+        [
+            Buffer.from("metadata"),
+            TOKEN_METADATA_PROGRAM_ID.toBuffer(),
+            mint.toBuffer(),
+        ],
+        TOKEN_METADATA_PROGRAM_ID,
+    );
+
+    const createMetadataIx = createCreateMetadataAccountV3Instruction(
+        {
+            metadata: metadataPda,
+            mint,
+            payer: solana.wallet.payer.publicKey,
+            mintAuthority: solana.wallet.payer.publicKey,
+            updateAuthority: solana.wallet.payer.publicKey,
+        },
+        {
+            createMetadataAccountArgsV3: {
+                data: metadataData,
+                isMutable: true,
+                collectionDetails: null,
+            },
+        },
+    );
+
+    const createMetadataTx = new solanaWeb3.Transaction().add(createMetadataIx);
+
+    await solana.provider.sendAndConfirm(createMetadataTx);
+
+    return [mint, associatedTokenAccount, metadataPda];
 }
 
 function getContractInfo(contractName, chainName) {
@@ -176,15 +304,22 @@ function getContractInfo(contractName, chainName) {
 }
 
 function generateRandomString(length) {
-    const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-    let result = '';
+    const characters =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+    let result = "";
     const charactersLength = characters.length;
 
     for (let i = 0; i < length; i++) {
-        result += characters.charAt(Math.floor(Math.random() * charactersLength));
+        result += characters.charAt(
+            Math.floor(Math.random() * charactersLength),
+        );
     }
 
     return result;
+}
+
+function trimNullTermination(str) {
+    return str.replace(/\0+$/, "");
 }
 
 module.exports = {
@@ -196,5 +331,8 @@ module.exports = {
     getContractJSON,
     getEvmContract,
     setupConnections,
-    waitForGmpExecution
+    setupSolanaMint,
+    waitForGmpExecution,
+    getRandomBytes32,
+    trimNullTermination,
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -25,6 +25,7 @@ const {
 } = require("ethers/lib/utils");
 
 require("dotenv").config();
+require("dotenv").config({ path: "./.env.test" });
 
 let chainsInfo;
 
@@ -178,12 +179,12 @@ async function waitForGmpExecution(txHash, axelar) {
     });
 }
 
-function setupConnections() {
+function setupConnections(evmKeyEnvVar) {
     const chainsInfo = getChainsInfo();
 
     const evmRpc = chainsInfo.chains[process.env.EVM_CHAIN].rpc;
     const evmProvider = new ethers.providers.JsonRpcProvider(evmRpc);
-    const evmWallet = new ethers.Wallet(process.env.EVM_KEY, evmProvider);
+    const evmWallet = new ethers.Wallet(process.env[evmKeyEnvVar], evmProvider);
 
     const solanaRpc = chainsInfo.chains[process.env.SOLANA_CHAIN].rpc;
     const solanaConnection = new solanaWeb3.Connection(solanaRpc, {
@@ -322,7 +323,20 @@ function trimNullTermination(str) {
     return str.replace(/\0+$/, "");
 }
 
+function toSnakeCaseCapital(str) {
+    return str
+        // Insert an underscore between a lowercase/number and uppercase letter
+        .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+        // Insert an underscore between consecutive uppercase letters when followed by a lowercase
+        .replace(/([A-Z])([A-Z][a-z])/g, "$1_$2")
+        // Convert spaces or hyphens to underscores
+        .replace(/[\s-]+/g, "_")
+        // Finally uppercase the entire thing
+        .toUpperCase();
+}
+
 module.exports = {
+    toSnakeCaseCapital,
     deployEvmContract,
     findProjectRoot,
     generateRandomString,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -171,7 +171,7 @@ async function waitForGmpExecution(txHash, axelar) {
             ) {
                 reject(new Error("Error executing the transaction"));
             }
-        });
+        }, { kind: "polling", interval: 500 });
 
         subscription.catch((error) => {
             reject(error);
@@ -190,7 +190,7 @@ function setupConnections(evmKeyEnvVar) {
     const solanaConnection = new solanaWeb3.Connection(solanaRpc, {
         commitment: "finalized",
         /** time to allow for the server to initially process a transaction (in milliseconds) */
-        confirmTransactionInitialTimeout: 720000,
+        confirmTransactionInitialTimeout: 900000,
     });
     const solanaWallet = new Wallet(
         Keypair.fromSecretKey(
@@ -200,7 +200,7 @@ function setupConnections(evmKeyEnvVar) {
     const solanaProvider = new anchor.AnchorProvider(
         solanaConnection,
         solanaWallet,
-        { commitment: "processed" },
+        { commitment: "finalized" },
     );
     const solanaGasServiceInfo = getContractInfo(
         "axelar_solana_gas_service",
@@ -297,7 +297,54 @@ async function setupSolanaMint(solana, name, symbol, decimals, initiaSupply) {
 
     await solana.provider.sendAndConfirm(createMetadataTx);
 
+
     return [mint, associatedTokenAccount, metadataPda];
+}
+
+// Sends transactions to solana and retries if it fails due to timeout. This
+// happens until the transaction succeeds.
+async function sendSolanaTransaction(solana, transaction, additionalSigners = []) {
+    const { blockhash, lastValidBlockHeight } = await solana.connection.getLatestBlockhash();
+    transaction.recentBlockhash = blockhash;
+    transaction.feePayer = solana.wallet.payer.publicKey;
+
+    if (additionalSigners.length > 0) {
+        transaction.partialSign(...additionalSigners);
+    }
+
+    const signedTransaction = await solana.wallet.signTransaction(transaction);
+    const txId = await solana.connection.sendRawTransaction(signedTransaction.serialize());
+
+    while (true) {
+        try {
+            const confirmation = await solana.connection.confirmTransaction(txId, 'finalized');
+            if (confirmation.value && confirmation.value.err) {
+                throw new Error(`Confirmation error: ${JSON.stringify(confirmation.value.err)}`);
+            }
+
+            return txId;
+        } catch (error) {
+            if (error instanceof solanaWeb3.TransactionExpiredTimeoutError) {
+                console.warn('Transaction timed out waiting for confirmation. Waiting further until confirmation or blockhash expiration.');
+            } else if (error instanceof solanaWeb3.TransactionExpiredBlockheightExceededError) {
+                console.warn('Blockhash expired.');
+                break;
+            } else {
+                throw error;
+            }
+        }
+
+        const { blockHeight: currentBlockHeight } = await solana.connection.getEpochInfo();
+        if (currentBlockHeight > lastValidBlockHeight) {
+            console.warn(`Current blockheight (${currentBlockHeight}) > lastValidBlockHeight (${lastValidBlockHeight}).`);
+            break;
+        }
+    }
+
+    console.log('Re-signing and resending the transaction with a new blockhash.');
+
+    const newTransaction = transaction;
+    return sendSolanaTransaction(solana, newTransaction, additionalSigners);
 }
 
 function getContractInfo(contractName, chainName) {
@@ -349,4 +396,5 @@ module.exports = {
     waitForGmpExecution,
     getRandomBytes32,
     trimNullTermination,
+    sendSolanaTransaction,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,9 @@
     "": {
       "dependencies": {
         "@axelar-network/axelarjs-sdk": "^0.17.3-alpha.6",
-        "@native-to-anchor/axelar-solana": "file:solana-axelar/solana/bindings/generated",
+        "@coral-xyz/anchor": "^0.29.0",
+        "@eiger/solana-axelar": "file:solana-axelar/solana/bindings",
+        "@metaplex-foundation/mpl-token-metadata": "^2.13.0",
         "chai": "^4.2.0",
         "commander": "^13.1.0",
         "crypto": "^1.0.1",
@@ -16,6 +18,9 @@
         "ethers": "^5.7",
         "mocha": "^11.1.0",
         "typescript": "^5.8.2"
+      },
+      "devDependencies": {
+        "@types/mocha": "^10.0.10"
       }
     },
     "node_modules/@0no-co/graphql.web": {
@@ -419,6 +424,10 @@
       "integrity": "sha512-pqsnp2BUYlDoTXWG34HWgEJse/Eo1okRgNex8IG84wHrJp8h3SakeR5WhB4VxSA2+/D+frNYJ0ch3yXzsfNDoA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@eiger/solana-axelar": {
+      "resolved": "solana-axelar/solana/bindings",
+      "link": true
     },
     "node_modules/@ensdomains/ens": {
       "version": "0.4.5",
@@ -2375,6 +2384,84 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@metaplex-foundation/beet": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@metaplex-foundation/beet/-/beet-0.7.2.tgz",
+      "integrity": "sha512-K+g3WhyFxKPc0xIvcIjNyV1eaTVJTiuaHZpig7Xx0MuYRMoJLLvhLTnUXhFdR5Tu2l2QSyKwfyXDgZlzhULqFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ansicolors": "^0.3.2",
+        "assert": "^2.1.0",
+        "bn.js": "^5.2.0",
+        "debug": "^4.3.3"
+      }
+    },
+    "node_modules/@metaplex-foundation/beet-solana": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@metaplex-foundation/beet-solana/-/beet-solana-0.4.1.tgz",
+      "integrity": "sha512-/6o32FNUtwK8tjhotrvU/vorP7umBuRFvBZrC6XCk51aKidBHe5LPVPA5AjGPbV3oftMfRuXPNd9yAGeEqeCDQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@metaplex-foundation/beet": ">=0.1.0",
+        "@solana/web3.js": "^1.56.2",
+        "bs58": "^5.0.0",
+        "debug": "^4.3.4"
+      }
+    },
+    "node_modules/@metaplex-foundation/beet-solana/node_modules/base-x": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.1.tgz",
+      "integrity": "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw==",
+      "license": "MIT"
+    },
+    "node_modules/@metaplex-foundation/beet-solana/node_modules/bs58": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
+      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^4.0.0"
+      }
+    },
+    "node_modules/@metaplex-foundation/cusper": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@metaplex-foundation/cusper/-/cusper-0.0.2.tgz",
+      "integrity": "sha512-S9RulC2fFCFOQraz61bij+5YCHhSO9llJegK8c8Y6731fSi6snUSQJdCUqYS8AIgR0TKbQvdvgSyIIdbDFZbBA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@metaplex-foundation/mpl-token-metadata": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@metaplex-foundation/mpl-token-metadata/-/mpl-token-metadata-2.13.0.tgz",
+      "integrity": "sha512-Fl/8I0L9rv4bKTV/RAl5YIbJe9SnQPInKvLz+xR1fEc4/VQkuCn3RPgypfUMEKWmCznzaw4sApDxy6CFS4qmJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@metaplex-foundation/beet": "^0.7.1",
+        "@metaplex-foundation/beet-solana": "^0.4.0",
+        "@metaplex-foundation/cusper": "^0.0.2",
+        "@solana/spl-token": "^0.3.6",
+        "@solana/web3.js": "^1.66.2",
+        "bn.js": "^5.2.0",
+        "debug": "^4.3.4"
+      }
+    },
+    "node_modules/@metaplex-foundation/mpl-token-metadata/node_modules/@solana/spl-token": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.3.11.tgz",
+      "integrity": "sha512-bvohO3rIMSVL24Pb+I4EYTJ6cL82eFpInEXD/I8K8upOGjpqHsKUoAempR/RnUlI1qSFNyFlWJfu6MNUgfbCQQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@solana/buffer-layout": "^4.0.0",
+        "@solana/buffer-layout-utils": "^0.2.0",
+        "@solana/spl-token-metadata": "^0.1.2",
+        "buffer": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.88.0"
+      }
+    },
     "node_modules/@mysten/bcs": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@mysten/bcs/-/bcs-1.5.0.tgz",
@@ -2405,10 +2492,6 @@
       "engines": {
         "node": ">=18"
       }
-    },
-    "node_modules/@native-to-anchor/axelar-solana": {
-      "resolved": "solana-axelar/solana/bindings/generated",
-      "link": true
     },
     "node_modules/@native-to-anchor/buffer-layout": {
       "version": "0.1.0",
@@ -2820,6 +2903,180 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@solana/codecs": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-2.0.0-rc.1.tgz",
+      "integrity": "sha512-qxoR7VybNJixV51L0G1RD2boZTcxmwUWnKCaJJExQ5qNKwbpSyDdWfFJfM5JhGyKe9DnPVOZB+JHWXnpbZBqrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-data-structures": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/codecs-strings": "2.0.0-rc.1",
+        "@solana/options": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/codecs-core": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0-rc.1.tgz",
+      "integrity": "sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/codecs-data-structures": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.0.0-rc.1.tgz",
+      "integrity": "sha512-rinCv0RrAVJ9rE/rmaibWJQxMwC5lSaORSZuwjopSUE6T0nb/MVg6Z1siNCXhh/HFTOg0l8bNvZHgBcN/yvXog==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/codecs-numbers": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0-rc.1.tgz",
+      "integrity": "sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/codecs-strings": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0-rc.1.tgz",
+      "integrity": "sha512-9/wPhw8TbGRTt6mHC4Zz1RqOnuPTqq1Nb4EyuvpZ39GW6O2t2Q7Q0XxiB3+BdoEjwA2XgPw6e2iRfvYgqty44g==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/errors": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0-rc.1.tgz",
+      "integrity": "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/errors/node_modules/chalk": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/errors/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@solana/options": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-2.0.0-rc.1.tgz",
+      "integrity": "sha512-mLUcR9mZ3qfHlmMnREdIFPf9dpMc/Bl66tLSOOWxw4ml5xMT2ohFn7WGqoKcu/UHkT9CrC6+amEdqCNvUqI7AA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-data-structures": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/codecs-strings": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token": {
+      "version": "0.4.13",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.4.13.tgz",
+      "integrity": "sha512-cite/pYWQZZVvLbg5lsodSovbetK/eA24gaR0eeUeMuBAMNrT8XFCwaygKy0N2WSg3gSyjjNpIeAGBAKZaY/1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@solana/buffer-layout": "^4.0.0",
+        "@solana/buffer-layout-utils": "^0.2.0",
+        "@solana/spl-token-group": "^0.0.7",
+        "@solana/spl-token-metadata": "^0.1.6",
+        "buffer": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.95.5"
+      }
+    },
+    "node_modules/@solana/spl-token-group": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token-group/-/spl-token-group-0.0.7.tgz",
+      "integrity": "sha512-V1N/iX7Cr7H0uazWUT2uk27TMqlqedpXHRqqAbVO2gvmJyT0E0ummMEAVQeXZ05ZhQ/xF39DLSdBp90XebWEug==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@solana/codecs": "2.0.0-rc.1"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.95.3"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token-metadata/-/spl-token-metadata-0.1.6.tgz",
+      "integrity": "sha512-7sMt1rsm/zQOQcUWllQX9mD2O6KhSAtY1hFR2hfFwgqfFWzSY9E9GDvFVNYUI1F0iQKcm6HmePU9QbKRXTEBiA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@solana/codecs": "2.0.0-rc.1"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.95.3"
+      }
+    },
     "node_modules/@solana/web3.js": {
       "version": "1.98.0",
       "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.98.0.tgz",
@@ -3039,9 +3296,9 @@
       }
     },
     "node_modules/@types/mocha": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
-      "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
+      "version": "10.0.10",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
+      "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -3238,6 +3495,12 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/ansicolors": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
+      "integrity": "sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg==",
+      "license": "MIT"
+    },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -3285,6 +3548,19 @@
         "safer-buffer": "~2.1.0"
       }
     },
+    "node_modules/assert": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
+      "integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "is-nan": "^1.3.2",
+        "object-is": "^1.1.5",
+        "object.assign": "^4.1.4",
+        "util": "^0.12.5"
+      }
+    },
     "node_modules/assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -3326,6 +3602,21 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/aws-sign2": {
       "version": "0.7.0",
@@ -3729,6 +4020,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -4982,6 +5291,13 @@
       "integrity": "sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==",
       "license": "MIT"
     },
+    "node_modules/fastestsmallesttextencoderdecoder": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
+      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==",
+      "license": "CC0-1.0",
+      "peer": true
+    },
     "node_modules/feaxios": {
       "version": "0.0.23",
       "resolved": "https://registry.npmjs.org/feaxios/-/feaxios-0.0.23.tgz",
@@ -5064,6 +5380,21 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/foreground-child": {
@@ -6044,6 +6375,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -6061,6 +6408,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-core-module": {
@@ -6096,6 +6455,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-generator-function": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
+      "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.0",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -6124,6 +6501,22 @@
       "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-nan": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -6165,6 +6558,24 @@
         "@types/estree": "*"
       }
     },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-retry-allowed": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-3.0.0.tgz",
@@ -6175,6 +6586,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-typedarray": {
@@ -7275,6 +7701,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -7282,6 +7724,26 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/once": {
@@ -7534,6 +7996,15 @@
       "resolved": "https://registry.npmjs.org/poseidon-lite/-/poseidon-lite-0.2.1.tgz",
       "integrity": "sha512-xIr+G6HeYfOhCuswdqcFpSX47SPhm0EpisWJ6h7fHlWwaVIvH3dLnejpatrtw6Xc6HaLrpq05y7VRfvDmDGIog==",
       "license": "MIT"
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/prettier": {
       "version": "2.7.1",
@@ -8007,6 +8478,23 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -8079,6 +8567,23 @@
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "license": "ISC",
       "peer": true
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/setimmediate": {
       "version": "1.0.5",
@@ -9009,6 +9514,19 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -9190,6 +9708,27 @@
       "integrity": "sha512-F6+WgncZi/mJDrammbTuHe1q0R5hOXv/mBaiNA2TCNT/LTHusX0V+CJnj9XT8ki5ln2UZyyddDgHfCzyrOH7MQ==",
       "license": "ISC",
       "peer": true
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
+      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/window-size": {
       "version": "0.2.0",
@@ -9400,12 +9939,65 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "solana-axelar/solana/bindings/generated": {
-      "name": "@native-to-anchor/axelar-solana",
+    "solana-axelar/solana/bindings": {
+      "name": "@eiger/solana-axelar",
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "^0.29.0",
+        "@native-to-anchor/buffer-layout": "=0.1.0",
+        "@noble/hashes": "^1.3.0",
+        "@solana/spl-token": "^0.4.13",
+        "@solana/web3.js": "^1.87.0",
+        "ethers": "^5.7"
+      },
+      "devDependencies": {
+        "@noble/hashes": "^1.3.0",
+        "@rollup/plugin-commonjs": "=21.0.2",
+        "@rollup/plugin-node-resolve": "=13.1.3",
+        "@rollup/plugin-replace": "=3.1.0",
+        "@rollup/plugin-typescript": "=8.3.1",
+        "@solana-developers/node-helpers": "^1.2.2",
+        "@solana/spl-token": "^0.4.13",
+        "@types/bn.js": "^5.1.0",
+        "@types/chai": "^4.3.0",
+        "@types/mocha": "^9.1.1",
+        "@types/node": "=17.0.21",
+        "chai": "^4.3.4",
+        "ethers": "^5.7",
+        "mocha": "^9.0.3",
+        "prettier": "=2.7.1",
+        "rimraf": "=3.0.2",
+        "rollup": "=2.70.1",
+        "rollup-plugin-terser": "=7.0.2",
+        "ts-mocha": "^10.0.0",
+        "tslib": "=2.3.1",
+        "typescript": "^5.0.0"
+      }
+    },
+    "solana-axelar/solana/bindings/axelar-solana-its": {
+      "version": "0.1.0",
+      "extraneous": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@coral-xyz/anchor": "^0.29.0",
+        "@native-to-anchor/axelar-solana-generated": "file:../generated",
+        "@noble/hashes": "^1.3.0",
+        "@solana/spl-token": "^0.4.13",
+        "@solana/web3.js": "^1.87.0",
+        "ethers": "^5.7"
+      },
+      "devDependencies": {
+        "typescript": "^5.0.0"
+      }
+    },
+    "solana-axelar/solana/bindings/generated": {
+      "name": "@native-to-anchor/axelar-solana",
+      "version": "0.1.0",
+      "extraneous": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
         "@native-to-anchor/buffer-layout": "=0.1.0"
       },
       "devDependencies": {
@@ -9428,9 +10020,19 @@
         "ts-mocha": "^10.0.0",
         "tslib": "=2.3.1",
         "typescript": "=4.6.2"
+      },
+      "peerDependencies": {
+        "@coral-xyz/anchor": "^0.29.0"
       }
     },
-    "solana-axelar/solana/bindings/generated/node_modules/ansi-colors": {
+    "solana-axelar/solana/bindings/node_modules/@types/mocha": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
+      "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "solana-axelar/solana/bindings/node_modules/ansi-colors": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
       "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
@@ -9440,7 +10042,7 @@
         "node": ">=6"
       }
     },
-    "solana-axelar/solana/bindings/generated/node_modules/chokidar": {
+    "solana-axelar/solana/bindings/node_modules/chokidar": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
       "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
@@ -9468,7 +10070,7 @@
         "fsevents": "~2.3.2"
       }
     },
-    "solana-axelar/solana/bindings/generated/node_modules/cliui": {
+    "solana-axelar/solana/bindings/node_modules/cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
       "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
@@ -9480,7 +10082,7 @@
         "wrap-ansi": "^7.0.0"
       }
     },
-    "solana-axelar/solana/bindings/generated/node_modules/debug": {
+    "solana-axelar/solana/bindings/node_modules/debug": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
       "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
@@ -9498,14 +10100,14 @@
         }
       }
     },
-    "solana-axelar/solana/bindings/generated/node_modules/debug/node_modules/ms": {
+    "solana-axelar/solana/bindings/node_modules/debug/node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true,
       "license": "MIT"
     },
-    "solana-axelar/solana/bindings/generated/node_modules/diff": {
+    "solana-axelar/solana/bindings/node_modules/diff": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
       "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
@@ -9515,7 +10117,7 @@
         "node": ">=0.3.1"
       }
     },
-    "solana-axelar/solana/bindings/generated/node_modules/glob": {
+    "solana-axelar/solana/bindings/node_modules/glob": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
       "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
@@ -9537,7 +10139,7 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "solana-axelar/solana/bindings/generated/node_modules/mocha": {
+    "solana-axelar/solana/bindings/node_modules/mocha": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz",
       "integrity": "sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==",
@@ -9581,7 +10183,7 @@
         "url": "https://opencollective.com/mochajs"
       }
     },
-    "solana-axelar/solana/bindings/generated/node_modules/mocha/node_modules/minimatch": {
+    "solana-axelar/solana/bindings/node_modules/mocha/node_modules/minimatch": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
       "integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
@@ -9594,7 +10196,7 @@
         "node": ">=10"
       }
     },
-    "solana-axelar/solana/bindings/generated/node_modules/serialize-javascript": {
+    "solana-axelar/solana/bindings/node_modules/serialize-javascript": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
       "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
@@ -9604,28 +10206,14 @@
         "randombytes": "^2.1.0"
       }
     },
-    "solana-axelar/solana/bindings/generated/node_modules/typescript": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
-      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
-    "solana-axelar/solana/bindings/generated/node_modules/workerpool": {
+    "solana-axelar/solana/bindings/node_modules/workerpool": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
       "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
       "dev": true,
       "license": "Apache-2.0"
     },
-    "solana-axelar/solana/bindings/generated/node_modules/yargs": {
+    "solana-axelar/solana/bindings/node_modules/yargs": {
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
       "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
@@ -9644,7 +10232,7 @@
         "node": ">=10"
       }
     },
-    "solana-axelar/solana/bindings/generated/node_modules/yargs-parser": {
+    "solana-axelar/solana/bindings/node_modules/yargs-parser": {
       "version": "20.2.4",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
       "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9946,13 +9946,11 @@
       "dependencies": {
         "@coral-xyz/anchor": "^0.29.0",
         "@native-to-anchor/buffer-layout": "=0.1.0",
-        "@noble/hashes": "^1.3.0",
         "@solana/spl-token": "^0.4.13",
         "@solana/web3.js": "^1.87.0",
         "ethers": "^5.7"
       },
       "devDependencies": {
-        "@noble/hashes": "^1.3.0",
         "@rollup/plugin-commonjs": "=21.0.2",
         "@rollup/plugin-node-resolve": "=13.1.3",
         "@rollup/plugin-replace": "=3.1.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "typescript": "^5.8.2"
   },
   "scripts": {
-    "test": "mocha"
+    "test": "mocha --parallel --require lib/test_funding.js"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.10"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "type": "commonjs",
   "dependencies": {
     "@axelar-network/axelarjs-sdk": "^0.17.3-alpha.6",
-    "@native-to-anchor/axelar-solana": "file:solana-axelar/solana/bindings/generated",
+    "@coral-xyz/anchor": "^0.29.0",
+    "@metaplex-foundation/mpl-token-metadata": "^2.13.0",
+    "@eiger/solana-axelar": "file:solana-axelar/solana/bindings",
     "chai": "^4.2.0",
     "commander": "^13.1.0",
     "crypto": "^1.0.1",
@@ -14,6 +16,9 @@
     "typescript": "^5.8.2"
   },
   "scripts": {
-    "test": "mocha --parallel"
+    "test": "mocha"
+  },
+  "devDependencies": {
+    "@types/mocha": "^10.0.10"
   }
 }

--- a/test-contracts.json
+++ b/test-contracts.json
@@ -12,8 +12,17 @@
                 "api": "https://explorer-api.devnet.solana.com"
             },
             "contracts": {
+                "axelar_solana_gas_service": {
+                    "address": "gasFkyvr4LjK3WwnMGbao3Wzr67F88TmhKmi4ZCXF9K",
+                    "config_pda": "GNNNDeAMMdYfN5RGizXN4DdpTpBXWa9UvFLg4JyvivvK"
+                },
                 "axelar_solana_memo_program": {
                     "address": "mem7LhKWbKydCPk1TwNzeCvVSpoVx2mqxNuvjGgWAbG"
+                },
+                "axelar_solana_its": {
+                    "address": "itsbPmAntHfec9PpLDoh9y3UiAEPT7DnzSvoJzdzZqd",
+                    "operator": "5Jja5kAvCFkixQSQhKpKWgWRx8FX6eh3FXH7oqJ98x7",
+                    "its_hub_address": "axelar157hl7gpuknjmhtac2qnphuazv2yerfagva7lsu9vuj2pgn32z22qa26dk4"
                 }
             }
         },

--- a/test/interchain-memo.js
+++ b/test/interchain-memo.js
@@ -2,6 +2,7 @@ const chai = require("chai");
 const ethers = require("ethers");
 const solanaWeb3 = require("@solana/web3.js");
 const utils = require("../lib/utils.js");
+const path = require("path");
 
 const { AXELAR_SOLANA_GATEWAY_PROGRAM_ID } = require(
     "@eiger/solana-axelar/anchor/gateway",
@@ -20,7 +21,9 @@ chai.use(solidity);
 describe("AxelarMemo Flow", function() {
     this.timeout("20m");
 
-    const setup = utils.setupConnections();
+    const fileName = path.parse(__filename).name;
+    const evmKeyEnvVar = utils.toSnakeCaseCapital(fileName);
+    const setup = utils.setupConnections(evmKeyEnvVar);
     const evmMemoInfo = utils.getContractInfo(
         "AxelarMemo",
         setup.evm.chainName,

--- a/test/interchain-memo.js
+++ b/test/interchain-memo.js
@@ -19,7 +19,7 @@ const { utils: { toUtf8Bytes } } = ethers;
 chai.use(solidity);
 
 describe("AxelarMemo Flow", function() {
-    this.timeout("20m");
+    this.timeout("60m");
 
     const fileName = path.parse(__filename).name;
     const evmKeyEnvVar = utils.toSnakeCaseCapital(fileName);

--- a/test/interchain-memo.js
+++ b/test/interchain-memo.js
@@ -1,31 +1,42 @@
-const chai = require('chai')
-const ethers = require('ethers')
-const solanaWeb3 = require('@solana/web3.js')
-const utils = require('../lib/utils');
+const chai = require("chai");
+const ethers = require("ethers");
+const solanaWeb3 = require("@solana/web3.js");
+const utils = require("../lib/utils.js");
 
-const { AXELAR_SOLANA_GATEWAY_PROGRAM_ID } = require('@native-to-anchor/axelar-solana/gateway');
+const { AXELAR_SOLANA_GATEWAY_PROGRAM_ID } = require(
+    "@eiger/solana-axelar/anchor/gateway",
+);
 const { PublicKey } = solanaWeb3;
-const { axelarSolanaMemoProgramProgram, AXELAR_SOLANA_MEMO_PROGRAM_PROGRAM_ID } = require('@native-to-anchor/axelar-solana/memo-program');
+const {
+    axelarSolanaMemoProgramProgram,
+    AXELAR_SOLANA_MEMO_PROGRAM_PROGRAM_ID,
+} = require("@eiger/solana-axelar/anchor/memo-program");
 const { expect } = chai;
-const { solidity } = require('ethereum-waffle');
+const { solidity } = require("ethereum-waffle");
 const { utils: { toUtf8Bytes } } = ethers;
 
 chai.use(solidity);
 
-describe('AxelarMemo Flow', function() {
-    this.timeout('20m');
+describe("AxelarMemo Flow", function() {
+    this.timeout("20m");
 
     const setup = utils.setupConnections();
-    const evmMemoInfo = utils.getContractInfo('AxelarMemo', setup.evm.chainName);
-    const solanaMemoInfo = utils.getContractInfo('axelar_solana_memo_program', setup.solana.chainName);
-
-    const [gatewayRootPdaPublicKey,] = PublicKey.findProgramAddressSync(
-        [Buffer.from('gateway')],
-        AXELAR_SOLANA_GATEWAY_PROGRAM_ID
+    const evmMemoInfo = utils.getContractInfo(
+        "AxelarMemo",
+        setup.evm.chainName,
     );
-    const [counterPdaPublicKey,] = PublicKey.findProgramAddressSync(
+    const solanaMemoInfo = utils.getContractInfo(
+        "axelar_solana_memo_program",
+        setup.solana.chainName,
+    );
+
+    const [gatewayRootPdaPublicKey] = PublicKey.findProgramAddressSync(
+        [Buffer.from("gateway")],
+        AXELAR_SOLANA_GATEWAY_PROGRAM_ID,
+    );
+    const [counterPdaPublicKey] = PublicKey.findProgramAddressSync(
         [gatewayRootPdaPublicKey.toBuffer()],
-        AXELAR_SOLANA_MEMO_PROGRAM_PROGRAM_ID
+        AXELAR_SOLANA_MEMO_PROGRAM_PROGRAM_ID,
     );
 
     let solanaMemoProgram;
@@ -39,26 +50,26 @@ describe('AxelarMemo Flow', function() {
     before(async () => {
         solanaMemoProgram = axelarSolanaMemoProgramProgram({
             programId: new PublicKey(solanaMemoInfo.address),
-            provider: setup.solana.provider
+            provider: setup.solana.provider,
         });
 
         evmMemoContract = await utils.getEvmContract(
             setup.evm.wallet,
-            'AxelarMemo',
-            evmMemoInfo.address
+            "AxelarMemo",
+            evmMemoInfo.address,
         );
     });
 
-    it('Should send memo from Solana and receive on EVM', async () => {
-        const [signingPda,] = PublicKey.findProgramAddressSync(
-            [Buffer.from('gtw-call-contract')],
-            AXELAR_SOLANA_MEMO_PROGRAM_PROGRAM_ID
+    it("Should send memo from Solana and receive on EVM", async () => {
+        const [signingPda] = PublicKey.findProgramAddressSync(
+            [Buffer.from("gtw-call-contract")],
+            AXELAR_SOLANA_MEMO_PROGRAM_PROGRAM_ID,
         );
 
         let txHash = await solanaMemoProgram.methods.sendToGateway(
             memo,
             setup.evm.chainName,
-            evmMemoInfo.address
+            evmMemoInfo.address,
         ).accounts({
             id: AXELAR_SOLANA_MEMO_PROGRAM_PROGRAM_ID,
             memoCounterPda: counterPdaPublicKey,
@@ -67,36 +78,47 @@ describe('AxelarMemo Flow', function() {
             gatewayProgram: AXELAR_SOLANA_GATEWAY_PROGRAM_ID,
         }).rpc();
 
-        console.log('    > Sent memo from solana to evm:', txHash);
+        const gmpDetails = await utils.waitForGmpExecution(
+            txHash,
+            setup.axelar,
+        );
+        const evmTx = await setup.evm.provider.getTransaction(
+            gmpDetails.executed.transactionHash,
+        );
 
-        const gmpDetails = await utils.waitForGmpExecution(txHash, setup.axelar);
-        const evmTx = await setup.evm.provider.getTransaction(gmpDetails.executed.transactionHash);
-
-        await expect(evmTx).to.emit(evmMemoContract, 'ReceivedMemo').withArgs(memo);
+        await expect(evmTx).to.emit(evmMemoContract, "ReceivedMemo").withArgs(
+            memo,
+        );
     });
 
-    it('Should send memo from EVM and receive on Solana', async () => {
+    it("Should send memo from EVM and receive on Solana", async () => {
         const tx = await evmMemoContract.sendToSolana(
             solanaMemoInfo.address,
             toUtf8Bytes(setup.solana.chainName),
             toUtf8Bytes(memo),
-            [{ pubkey: counterPdaPublicKey.toBytes(), isSigner: false, isWritable: true }]
+            [{
+                pubkey: counterPdaPublicKey.toBytes(),
+                isSigner: false,
+                isWritable: true,
+            }],
         );
 
-        console.log('    > Sent memo from evm to solana:', tx.hash);
-
-        const gmpDetails = await utils.waitForGmpExecution(tx.hash, setup.axelar);
+        const gmpDetails = await utils.waitForGmpExecution(
+            tx.hash,
+            setup.axelar,
+        );
         const solanaMemoLogs = await setup.solana.connection.getTransaction(
-            gmpDetails.executed.transactionHash, {
-            maxSupportedTransactionVersion: 0
-        }).then((response) => {
+            gmpDetails.executed.transactionHash,
+            {
+                maxSupportedTransactionVersion: 0,
+            },
+        ).then((response) => {
             return response.meta.logMessages;
         });
 
         expect(
-            solanaMemoLogs.some(log => log.includes(memo)),
-            `expected ${solanaMemoLogs} to have a log that includes ${memo}`
+            solanaMemoLogs.some((log) => log.includes(memo)),
+            `expected ${solanaMemoLogs} to have a log that includes ${memo}`,
         ).to.be.true;
-
     });
 });

--- a/test/interchain-memo.js
+++ b/test/interchain-memo.js
@@ -69,7 +69,7 @@ describe("AxelarMemo Flow", function() {
             AXELAR_SOLANA_MEMO_PROGRAM_PROGRAM_ID,
         );
 
-        let txHash = await solanaMemoProgram.methods.sendToGateway(
+        const tx = await solanaMemoProgram.methods.sendToGateway(
             memo,
             setup.evm.chainName,
             evmMemoInfo.address,
@@ -79,7 +79,8 @@ describe("AxelarMemo Flow", function() {
             signingPda0: signingPda,
             gatewayRootPda: gatewayRootPdaPublicKey,
             gatewayProgram: AXELAR_SOLANA_GATEWAY_PROGRAM_ID,
-        }).rpc();
+        }).transaction();
+        const txHash = await utils.sendSolanaTransaction(setup.solana, tx);
 
         const gmpDetails = await utils.waitForGmpExecution(
             txHash,
@@ -105,6 +106,7 @@ describe("AxelarMemo Flow", function() {
                 isWritable: true,
             }],
         );
+        tx.wait();
 
         const gmpDetails = await utils.waitForGmpExecution(
             tx.hash,

--- a/test/its-evm-solana-canonical-token.js
+++ b/test/its-evm-solana-canonical-token.js
@@ -1,6 +1,7 @@
 const chai = require("chai");
 const solanaWeb3 = require("@solana/web3.js");
 const utils = require("../lib/utils.js");
+const path = require("path");
 const { Buffer } = require("node:buffer");
 
 const { AXELAR_SOLANA_GATEWAY_PROGRAM_ID } = require(
@@ -28,7 +29,9 @@ chai.use(solidity);
 describe("EVM -> Solana Canonical Interchain Token", function() {
     this.timeout("20m");
 
-    const setup = utils.setupConnections();
+    const fileName = path.parse(__filename).name;
+    const evmKeyEnvVar = utils.toSnakeCaseCapital(fileName);
+    const setup = utils.setupConnections(evmKeyEnvVar);
     const evmItsInfo = utils.getContractInfo(
         "InterchainTokenService",
         setup.evm.chainName,

--- a/test/its-evm-solana-canonical-token.js
+++ b/test/its-evm-solana-canonical-token.js
@@ -146,7 +146,7 @@ describe("EVM -> Solana Canonical Interchain Token", function() {
                 );
         });
 
-        it("Should be able to trnsfer tokens from EVM to Solana", async () => {
+        it("Should be able to transfer tokens from EVM to Solana", async () => {
             const approvalTx = await token.approve(evmItsContract.address, transferAmount);
             await approvalTx.wait();
 

--- a/test/its-evm-solana-canonical-token.js
+++ b/test/its-evm-solana-canonical-token.js
@@ -181,7 +181,7 @@ describe("EVM -> Solana Canonical Interchain Token", function() {
         });
 
         it("Should be able to transfer tokens from Solana to EVM", async () => {
-            const txHash = await solanaItsProgram.interchainTransfer({
+            const tx = await solanaItsProgram.interchainTransfer({
                 payer: setup.solana.wallet.payer.publicKey,
                 sourceAccount: associatedTokenAccount.address,
                 authority: setup.solana.wallet.payer.publicKey,
@@ -194,7 +194,8 @@ describe("EVM -> Solana Canonical Interchain Token", function() {
                 gasService: setup.solana.gasService,
                 gasConfigPda: setup.solana.gasConfigPda,
                 tokenProgram: TOKEN_2022_PROGRAM_ID,
-            }).rpc();
+            }).transaction();
+            const txHash = await utils.sendSolanaTransaction(setup.solana, tx);
 
             const srcGmpDetails = await utils.waitForGmpExecution(
                 txHash,

--- a/test/its-evm-solana-canonical-token.js
+++ b/test/its-evm-solana-canonical-token.js
@@ -27,7 +27,7 @@ const { getOrCreateAssociatedTokenAccount, TOKEN_2022_PROGRAM_ID } = require(
 chai.use(solidity);
 
 describe("EVM -> Solana Canonical Interchain Token", function() {
-    this.timeout("20m");
+    this.timeout("60m");
 
     const fileName = path.parse(__filename).name;
     const evmKeyEnvVar = utils.toSnakeCaseCapital(fileName);

--- a/test/its-evm-solana-canonical-token.js
+++ b/test/its-evm-solana-canonical-token.js
@@ -1,0 +1,223 @@
+const chai = require("chai");
+const solanaWeb3 = require("@solana/web3.js");
+const utils = require("../lib/utils.js");
+const { Buffer } = require("node:buffer");
+
+const { AXELAR_SOLANA_GATEWAY_PROGRAM_ID } = require(
+    "@eiger/solana-axelar/anchor/gateway",
+);
+const { BN } = require("@coral-xyz/anchor");
+const {
+    ItsInstructions,
+    findInterchainTokenPda,
+    findMetadataPda,
+} = require(
+    "@eiger/solana-axelar/its"
+);
+const { PublicKey } = solanaWeb3;
+const { expect } = chai;
+const { solidity } = require("ethereum-waffle");
+const { utils: { arrayify } } = require("ethers");
+const { Metadata } = require("@metaplex-foundation/mpl-token-metadata");
+const { getOrCreateAssociatedTokenAccount, TOKEN_2022_PROGRAM_ID } = require(
+    "@solana/spl-token",
+);
+
+chai.use(solidity);
+
+describe("EVM -> Solana Canonical Interchain Token", function() {
+    this.timeout("20m");
+
+    const setup = utils.setupConnections();
+    const evmItsInfo = utils.getContractInfo(
+        "InterchainTokenService",
+        setup.evm.chainName,
+    );
+    const evmFactoryInfo = utils.getContractInfo(
+        "InterchainTokenFactory",
+        setup.evm.chainName,
+    );
+    const solanaItsInfo = utils.getContractInfo(
+        "axelar_solana_its",
+        setup.solana.chainName,
+    );
+
+    const [gatewayRootPdaPublicKey] = PublicKey.findProgramAddressSync(
+        [Buffer.from("gateway")],
+        AXELAR_SOLANA_GATEWAY_PROGRAM_ID,
+    );
+
+    const name = "MyToken";
+    const symbol = "MT";
+    const decimals = 6;
+    const transferAmount = 1e6;
+    const gasValue = 2500000;
+
+    let solanaItsProgram;
+    let evmItsContract;
+    let evmFactoryContract;
+
+    let token;
+    let solanaToken;
+    let tokenId;
+    let associatedTokenAccount;
+    let metadataPda;
+
+    before(async () => {
+        solanaItsProgram = new ItsInstructions(
+            new PublicKey(solanaItsInfo.address),
+            gatewayRootPdaPublicKey,
+            setup.solana.provider,
+        );
+
+        evmItsContract = await utils.getEvmContract(
+            setup.evm.wallet,
+            "InterchainTokenService",
+            evmItsInfo.address,
+        );
+
+        evmFactoryContract = await utils.getEvmContract(
+            setup.evm.wallet,
+            "InterchainTokenFactory",
+            evmFactoryInfo.address,
+        );
+
+        token = await utils.deployEvmContract(
+            setup.evm.wallet,
+            "CustomTestToken",
+            [
+                name,
+                symbol,
+                decimals,
+            ],
+        );
+
+        let mintTx = await token.mint(setup.evm.wallet.address, transferAmount);
+        await mintTx.wait();
+
+        tokenId = await evmFactoryContract.canonicalInterchainTokenId(token.address);
+        [solanaToken] = findInterchainTokenPda(solanaItsProgram.itsRootPda, arrayify(tokenId));
+        [metadataPda] = findMetadataPda(solanaToken);
+    });
+
+    it("Should register the token on EVM and deploy remotely on the Solana chain", async () => {
+        let registrationTx = await evmFactoryContract.registerCanonicalInterchainToken(token.address);
+        await registrationTx.wait();
+
+        const tx = await evmFactoryContract["deployRemoteCanonicalInterchainToken(address,string,uint256)"](
+            token.address,
+            setup.solana.chainName,
+            gasValue,
+            { value: gasValue },
+        );
+
+        const srcGmpDetails = await utils.waitForGmpExecution(
+            tx.hash,
+            setup.axelar,
+        );
+
+        await utils.waitForGmpExecution(
+            srcGmpDetails.executed.transactionHash,
+            setup.axelar,
+        );
+
+        const metadata = await Metadata.fromAccountAddress(setup.solana.connection, metadataPda);
+
+        expect(utils.trimNullTermination(metadata.data.name)).to.equal(name);
+        expect(utils.trimNullTermination(metadata.data.symbol)).to.equal(symbol);
+    });
+
+    describe("InterchainTransfer", () => {
+        before(async () => {
+            associatedTokenAccount =
+                // Native Interchain Tokens are always spl-token-2022
+                await getOrCreateAssociatedTokenAccount(
+                    setup.solana.connection,
+                    setup.solana.wallet.payer,
+                    solanaToken,
+                    setup.solana.wallet.payer.publicKey,
+                    false,
+                    null,
+                    null,
+                    TOKEN_2022_PROGRAM_ID,
+                );
+        });
+
+        it("Should be able to trnsfer tokens from EVM to Solana", async () => {
+            const approvalTx = await token.approve(evmItsContract.address, transferAmount);
+            await approvalTx.wait();
+
+            const tx = await evmItsContract.interchainTransfer(
+                tokenId,
+                setup.solana.chainName,
+                associatedTokenAccount.address.toBytes(),
+                Math.floor(transferAmount),
+                "0x",
+                gasValue,
+                { value: gasValue },
+            );
+
+            const srcGmpDetails = await utils.waitForGmpExecution(
+                tx.hash,
+                setup.axelar,
+            );
+            await utils.waitForGmpExecution(
+                srcGmpDetails.executed.transactionHash,
+                setup.axelar,
+            );
+
+            const currentBalance = Number(
+                (await setup.solana.connection.getTokenAccountBalance(
+                    associatedTokenAccount.address,
+                ))
+                    .value
+                    .amount,
+            );
+
+            expect(currentBalance).to.equal(transferAmount);
+        });
+
+        it("Should be able to transfer tokens from Solana to EVM", async () => {
+            const txHash = await solanaItsProgram.interchainTransfer({
+                payer: setup.solana.wallet.payer.publicKey,
+                sourceAccount: associatedTokenAccount.address,
+                authority: setup.solana.wallet.payer.publicKey,
+                tokenId: arrayify(tokenId),
+                destinationChain: setup.evm.chainName,
+                destinationAddress: arrayify(setup.evm.wallet.address),
+                amount: new BN(transferAmount),
+                mint: solanaToken,
+                gasValue: new BN(gasValue),
+                gasService: setup.solana.gasService,
+                gasConfigPda: setup.solana.gasConfigPda,
+                tokenProgram: TOKEN_2022_PROGRAM_ID,
+            }).rpc();
+
+            const srcGmpDetails = await utils.waitForGmpExecution(
+                txHash,
+                setup.axelar,
+            );
+            const dstGmpDetails = await utils.waitForGmpExecution(
+                srcGmpDetails.executed.transactionHash,
+                setup.axelar,
+            );
+            const evmTx = await setup.evm.provider.getTransaction(
+                dstGmpDetails.executed.transactionHash,
+            );
+
+            await expect(evmTx).to.emit(
+                evmItsContract,
+                "InterchainTransferReceived",
+            ).withNamedArgs({
+                tokenId,
+                amount: transferAmount,
+                sourceChain: setup.solana.chainName,
+            });
+
+            expect(
+                await token.balanceOf(setup.evm.wallet.address),
+            )
+                .to.equal(transferAmount);
+        });
+    });
+});

--- a/test/its-evm-solana-custom-token.js
+++ b/test/its-evm-solana-custom-token.js
@@ -28,7 +28,7 @@ const { GMPStatus } = require(
 chai.use(solidity);
 
 describe("EVM -> Solana Existing Custom Token", function() {
-    this.timeout("20m");
+    this.timeout("60m");
 
     const fileName = path.parse(__filename).name;
     const evmKeyEnvVar = utils.toSnakeCaseCapital(fileName);

--- a/test/its-evm-solana-custom-token.js
+++ b/test/its-evm-solana-custom-token.js
@@ -1,0 +1,276 @@
+const chai = require("chai");
+const solanaWeb3 = require("@solana/web3.js");
+const utils = require("../lib/utils.js");
+const { Buffer } = require("node:buffer");
+
+const { AXELAR_SOLANA_GATEWAY_PROGRAM_ID } = require(
+    "@eiger/solana-axelar/anchor/gateway",
+);
+const { BN } = require("@coral-xyz/anchor");
+const {
+    ItsInstructions,
+    TokenManagerType,
+} = require(
+    "@eiger/solana-axelar/its"
+);
+const { PublicKey } = solanaWeb3;
+const { expect } = chai;
+const { solidity } = require("ethereum-waffle");
+const { utils: { arrayify } } = require("ethers");
+const { getOrCreateAssociatedTokenAccount, TOKEN_PROGRAM_ID } = require(
+    "@solana/spl-token",
+);
+const { GMPStatus } = require(
+    "@axelar-network/axelarjs-sdk",
+);
+
+chai.use(solidity);
+
+describe("EVM -> Solana Existing Custom Token", function() {
+    this.timeout("20m");
+
+    const setup = utils.setupConnections();
+    const evmItsInfo = utils.getContractInfo(
+        "InterchainTokenService",
+        setup.evm.chainName,
+    );
+    const evmFactoryInfo = utils.getContractInfo(
+        "InterchainTokenFactory",
+        setup.evm.chainName,
+    );
+    const solanaItsInfo = utils.getContractInfo(
+        "axelar_solana_its",
+        setup.solana.chainName,
+    );
+
+    const [gatewayRootPdaPublicKey] = PublicKey.findProgramAddressSync(
+        [Buffer.from("gateway")],
+        AXELAR_SOLANA_GATEWAY_PROGRAM_ID,
+    );
+
+    const name = "MyToken";
+    const symbol = "MT";
+    const decimals = 6;
+    const transferAmount = 1e6;
+    const gasValue = 2500000;
+    const salt = utils.getRandomBytes32();
+
+    let solanaItsProgram;
+    let evmItsContract;
+    let evmFactoryContract;
+
+    let token;
+    let solanaToken;
+    let tokenId;
+    let associatedTokenAccount;
+    let _metadataPda;
+
+    before(async () => {
+        solanaItsProgram = new ItsInstructions(
+            new PublicKey(solanaItsInfo.address),
+            gatewayRootPdaPublicKey,
+            setup.solana.provider,
+        );
+        evmItsContract = await utils.getEvmContract(
+            setup.evm.wallet,
+            "InterchainTokenService",
+            evmItsInfo.address,
+        );
+        evmFactoryContract = await utils.getEvmContract(
+            setup.evm.wallet,
+            "InterchainTokenFactory",
+            evmFactoryInfo.address,
+        );
+
+        [solanaToken, associatedTokenAccount, _metadataPda] = await utils
+            .setupSolanaMint(
+                setup.solana,
+                name,
+                symbol,
+                decimals,
+                0
+            );
+
+        const solanaMetadataTxHash = await solanaItsProgram
+            .registerTokenMetadata({
+                payer: setup.solana.wallet.payer.publicKey,
+                mint: solanaToken,
+                tokenProgram: TOKEN_PROGRAM_ID,
+                gasValue: new BN(gasValue),
+                gasService: setup.solana.gasService,
+                gasConfigPda: setup.solana.gasConfigPda,
+            }).rpc();
+
+        token = await utils.deployEvmContract(
+            setup.evm.wallet,
+            "CustomTestToken",
+            [
+                name,
+                symbol,
+                decimals,
+            ],
+        );
+
+        const evmMetadataTx = await evmItsContract.registerTokenMetadata(
+            token.address,
+            gasValue,
+            { value: gasValue },
+        );
+        await evmMetadataTx.wait();
+
+
+        await utils.waitForGmpExecution(
+            evmMetadataTx.hash,
+            setup.axelar,
+        );
+
+        await utils.waitForGmpExecution(
+            solanaMetadataTxHash,
+            setup.axelar,
+        );
+
+
+        tokenId = await evmFactoryContract.linkedTokenId(setup.evm.wallet.address, salt);
+    });
+
+    it("Should register the token on EVM and deploy remotely on the Solana chain", async () => {
+        let registrationTx = await evmFactoryContract.registerCustomToken(
+            salt,
+            token.address,
+            TokenManagerType.MintBurn,
+            setup.evm.wallet.address
+        );
+        await registrationTx.wait();
+
+        const tx = await evmFactoryContract.linkToken(
+            salt,
+            setup.solana.chainName,
+            solanaToken.toBytes(),
+            TokenManagerType.MintBurn,
+            setup.evm.wallet.address,
+            gasValue,
+            { value: gasValue }
+        );
+
+        const srcGmpDetails = await utils.waitForGmpExecution(
+            tx.hash,
+            setup.axelar,
+        );
+
+        const dstGmpDetails = await utils.waitForGmpExecution(
+            srcGmpDetails.executed.transactionHash,
+            setup.axelar,
+        );
+
+        expect(dstGmpDetails.status).to.be.equal(GMPStatus.DEST_EXECUTED);
+    });
+
+    describe("InterchainTransfer", () => {
+        before(async () => {
+            associatedTokenAccount =
+                // Native Interchain Tokens are always spl-token-2022
+                await getOrCreateAssociatedTokenAccount(
+                    setup.solana.connection,
+                    setup.solana.wallet.payer,
+                    solanaToken,
+                    setup.solana.wallet.payer.publicKey,
+                    false,
+                    null,
+                    null,
+                    TOKEN_PROGRAM_ID,
+                );
+
+            let mintTx = await token.mint(setup.evm.wallet.address, transferAmount);
+            await mintTx.wait();
+
+            const evmTokenManagerAddress = await evmItsContract
+                .tokenManagerAddress(tokenId);
+
+            let mintershipTransferTx = await token.transferMintership(evmTokenManagerAddress);
+            await mintershipTransferTx.wait();
+
+
+            await solanaItsProgram.tokenManager.handOverMintAuthority({
+                payer: setup.solana.wallet.payer.publicKey,
+                tokenId: arrayify(tokenId),
+                mint: solanaToken,
+                TOKEN_PROGRAM_ID,
+            }).rpc();
+
+        });
+
+        it("Should be able to transfer tokens from EVM to Solana", async () => {
+            const tx = await evmItsContract.interchainTransfer(
+                tokenId,
+                setup.solana.chainName,
+                associatedTokenAccount.address.toBytes(),
+                Math.floor(transferAmount),
+                "0x",
+                gasValue,
+                { value: gasValue },
+            );
+
+            const srcGmpDetails = await utils.waitForGmpExecution(
+                tx.hash,
+                setup.axelar,
+            );
+            await utils.waitForGmpExecution(
+                srcGmpDetails.executed.transactionHash,
+                setup.axelar,
+            );
+
+            const currentBalance = Number(
+                (await setup.solana.connection.getTokenAccountBalance(
+                    associatedTokenAccount.address,
+                ))
+                    .value
+                    .amount,
+            );
+
+            expect(currentBalance).to.equal(transferAmount);
+        });
+
+        it("Should be able to transfer tokens from Solana to EVM", async () => {
+            const txHash = await solanaItsProgram.interchainTransfer({
+                payer: setup.solana.wallet.payer.publicKey,
+                sourceAccount: associatedTokenAccount.address,
+                authority: setup.solana.wallet.payer.publicKey,
+                tokenId: arrayify(tokenId),
+                destinationChain: setup.evm.chainName,
+                destinationAddress: arrayify(setup.evm.wallet.address),
+                amount: new BN(transferAmount),
+                mint: solanaToken,
+                gasValue: new BN(gasValue),
+                gasService: setup.solana.gasService,
+                gasConfigPda: setup.solana.gasConfigPda,
+                tokenProgram: TOKEN_PROGRAM_ID,
+            }).rpc();
+
+            const srcGmpDetails = await utils.waitForGmpExecution(
+                txHash,
+                setup.axelar,
+            );
+            const dstGmpDetails = await utils.waitForGmpExecution(
+                srcGmpDetails.executed.transactionHash,
+                setup.axelar,
+            );
+            const evmTx = await setup.evm.provider.getTransaction(
+                dstGmpDetails.executed.transactionHash,
+            );
+
+            await expect(evmTx).to.emit(
+                evmItsContract,
+                "InterchainTransferReceived",
+            ).withNamedArgs({
+                tokenId,
+                amount: transferAmount,
+                sourceChain: setup.solana.chainName,
+            });
+
+            expect(
+                await token.balanceOf(setup.evm.wallet.address),
+            )
+                .to.equal(transferAmount);
+        });
+    });
+});

--- a/test/its-evm-solana-custom-token.js
+++ b/test/its-evm-solana-custom-token.js
@@ -94,7 +94,7 @@ describe("EVM -> Solana Existing Custom Token", function() {
                 0
             );
 
-        const solanaMetadataTxHash = await solanaItsProgram
+        const solanaMetadataTx = await solanaItsProgram
             .registerTokenMetadata({
                 payer: setup.solana.wallet.payer.publicKey,
                 mint: solanaToken,
@@ -102,7 +102,8 @@ describe("EVM -> Solana Existing Custom Token", function() {
                 gasValue: new BN(gasValue),
                 gasService: setup.solana.gasService,
                 gasConfigPda: setup.solana.gasConfigPda,
-            }).rpc();
+            }).transaction();
+        const solanaMetadataTxHash = await utils.sendSolanaTransaction(setup.solana, solanaMetadataTx);
 
         token = await utils.deployEvmContract(
             setup.evm.wallet,
@@ -193,12 +194,13 @@ describe("EVM -> Solana Existing Custom Token", function() {
             await mintershipTransferTx.wait();
 
 
-            await solanaItsProgram.tokenManager.handOverMintAuthority({
+            const tx = await solanaItsProgram.tokenManager.handOverMintAuthority({
                 payer: setup.solana.wallet.payer.publicKey,
                 tokenId: arrayify(tokenId),
                 mint: solanaToken,
                 TOKEN_PROGRAM_ID,
-            }).rpc();
+            }).transaction();
+            await utils.sendSolanaTransaction(setup.solana, tx);
 
         });
 
@@ -234,7 +236,7 @@ describe("EVM -> Solana Existing Custom Token", function() {
         });
 
         it("Should be able to transfer tokens from Solana to EVM", async () => {
-            const txHash = await solanaItsProgram.interchainTransfer({
+            const tx = await solanaItsProgram.interchainTransfer({
                 payer: setup.solana.wallet.payer.publicKey,
                 sourceAccount: associatedTokenAccount.address,
                 authority: setup.solana.wallet.payer.publicKey,
@@ -247,7 +249,8 @@ describe("EVM -> Solana Existing Custom Token", function() {
                 gasService: setup.solana.gasService,
                 gasConfigPda: setup.solana.gasConfigPda,
                 tokenProgram: TOKEN_PROGRAM_ID,
-            }).rpc();
+            }).transaction();
+            const txHash = await utils.sendSolanaTransaction(setup.solana, tx);
 
             const srcGmpDetails = await utils.waitForGmpExecution(
                 txHash,

--- a/test/its-evm-solana-custom-token.js
+++ b/test/its-evm-solana-custom-token.js
@@ -1,6 +1,7 @@
 const chai = require("chai");
 const solanaWeb3 = require("@solana/web3.js");
 const utils = require("../lib/utils.js");
+const path = require("path");
 const { Buffer } = require("node:buffer");
 
 const { AXELAR_SOLANA_GATEWAY_PROGRAM_ID } = require(
@@ -29,7 +30,9 @@ chai.use(solidity);
 describe("EVM -> Solana Existing Custom Token", function() {
     this.timeout("20m");
 
-    const setup = utils.setupConnections();
+    const fileName = path.parse(__filename).name;
+    const evmKeyEnvVar = utils.toSnakeCaseCapital(fileName);
+    const setup = utils.setupConnections(evmKeyEnvVar);
     const evmItsInfo = utils.getContractInfo(
         "InterchainTokenService",
         setup.evm.chainName,

--- a/test/its-evm-solana-native-interchain-token.js
+++ b/test/its-evm-solana-native-interchain-token.js
@@ -1,0 +1,383 @@
+const chai = require("chai");
+const solanaWeb3 = require("@solana/web3.js");
+const utils = require("../lib/utils.js");
+const { Buffer } = require("node:buffer");
+
+const { AXELAR_SOLANA_GATEWAY_PROGRAM_ID } = require(
+    "@eiger/solana-axelar/anchor/gateway",
+);
+const { BN } = require("@coral-xyz/anchor");
+const {
+    ItsInstructions,
+    findInterchainTokenPda,
+    findMetadataPda,
+} = require(
+    "@eiger/solana-axelar/its"
+);
+const { PublicKey } = solanaWeb3;
+const { expect } = chai;
+const { solidity } = require("ethereum-waffle");
+const { utils: { arrayify, solidityPack } } = require("ethers");
+const { Metadata } = require("@metaplex-foundation/mpl-token-metadata");
+const { getOrCreateAssociatedTokenAccount, TOKEN_2022_PROGRAM_ID } = require(
+    "@solana/spl-token",
+);
+const {
+    axelarSolanaMemoProgramProgram,
+    AXELAR_SOLANA_MEMO_PROGRAM_PROGRAM_ID,
+} = require("@eiger/solana-axelar/anchor/memo-program");
+const {
+    SolanaAxelarExecutablePayload,
+    EncodingSchema
+} = require("@eiger/solana-axelar/executable");
+
+chai.use(solidity);
+
+describe("EVM -> Solana Native Interchain Token", function() {
+    this.timeout("20m");
+
+    const setup = utils.setupConnections();
+    const evmItsInfo = utils.getContractInfo(
+        "InterchainTokenService",
+        setup.evm.chainName,
+    );
+    const evmFactoryInfo = utils.getContractInfo(
+        "InterchainTokenFactory",
+        setup.evm.chainName,
+    );
+    const solanaItsInfo = utils.getContractInfo(
+        "axelar_solana_its",
+        setup.solana.chainName,
+    );
+
+    const [gatewayRootPdaPublicKey] = PublicKey.findProgramAddressSync(
+        [Buffer.from("gateway")],
+        AXELAR_SOLANA_GATEWAY_PROGRAM_ID,
+    );
+
+    const name = "MyToken";
+    const symbol = "MT";
+    const decimals = 6;
+    const transferAmount = 1e6;
+    const gasValue = 2500000;
+    const salt = utils.getRandomBytes32();
+
+    let solanaItsProgram;
+    let evmItsContract;
+    let evmFactoryContract;
+
+    let token;
+    let solanaToken;
+    let tokenId;
+    let associatedTokenAccount;
+    let metadataPda;
+
+    before(async () => {
+        solanaItsProgram = new ItsInstructions(
+            new PublicKey(solanaItsInfo.address),
+            gatewayRootPdaPublicKey,
+            setup.solana.provider,
+        );
+
+        evmItsContract = await utils.getEvmContract(
+            setup.evm.wallet,
+            "InterchainTokenService",
+            evmItsInfo.address,
+        );
+
+        evmFactoryContract = await utils.getEvmContract(
+            setup.evm.wallet,
+            "InterchainTokenFactory",
+            evmFactoryInfo.address,
+        );
+
+        tokenId = await evmFactoryContract.interchainTokenId(setup.evm.wallet.address, salt);
+        [solanaToken] = findInterchainTokenPda(solanaItsProgram.itsRootPda, arrayify(tokenId));
+        [metadataPda] = findMetadataPda(solanaToken);
+    });
+
+    it("Should register the token on EVM and deploy remotely on the Solana chain", async () => {
+        let deployTx = await evmFactoryContract.deployInterchainToken(
+            salt,
+            name,
+            symbol,
+            decimals,
+            transferAmount,
+            setup.evm.wallet.address,
+        );
+        await deployTx.wait();
+
+        let approvalTx = await evmFactoryContract.approveDeployRemoteInterchainToken(
+            setup.evm.wallet.address,
+            salt,
+            setup.solana.chainName,
+            setup.solana.wallet.payer.publicKey.toBytes(),
+        );
+        await approvalTx.wait();
+
+        const tx = await evmFactoryContract.deployRemoteInterchainTokenWithMinter(
+            salt,
+            setup.evm.wallet.address,
+            setup.solana.chainName,
+            setup.solana.wallet.payer.publicKey.toBytes(),
+            gasValue,
+            { value: gasValue },
+        );
+
+        const srcGmpDetails = await utils.waitForGmpExecution(
+            tx.hash,
+            setup.axelar,
+        );
+
+        await utils.waitForGmpExecution(
+            srcGmpDetails.executed.transactionHash,
+            setup.axelar,
+        );
+
+        const metadata = await Metadata.fromAccountAddress(setup.solana.connection, metadataPda);
+
+        expect(utils.trimNullTermination(metadata.data.name)).to.equal(name);
+        expect(utils.trimNullTermination(metadata.data.symbol)).to.equal(symbol);
+    });
+
+    describe("InterchainTransfer", () => {
+        before(async () => {
+            associatedTokenAccount =
+                // Native Interchain Tokens are always spl-token-2022
+                await getOrCreateAssociatedTokenAccount(
+                    setup.solana.connection,
+                    setup.solana.wallet.payer,
+                    solanaToken,
+                    setup.solana.wallet.payer.publicKey,
+                    false,
+                    null,
+                    null,
+                    TOKEN_2022_PROGRAM_ID,
+                );
+            const tokenAddress = await evmItsContract.registeredTokenAddress(tokenId);
+
+            token = await utils.getEvmContract(
+                setup.evm.wallet,
+                "InterchainToken",
+                tokenAddress,
+            );
+        });
+
+        it("Should be able to transfer tokens from EVM to Solana", async () => {
+            const tx = await evmItsContract.interchainTransfer(
+                tokenId,
+                setup.solana.chainName,
+                associatedTokenAccount.address.toBytes(),
+                Math.floor(transferAmount),
+                "0x",
+                gasValue,
+                { value: gasValue },
+            );
+
+            const srcGmpDetails = await utils.waitForGmpExecution(
+                tx.hash,
+                setup.axelar,
+            );
+            await utils.waitForGmpExecution(
+                srcGmpDetails.executed.transactionHash,
+                setup.axelar,
+            );
+
+            const currentBalance = Number(
+                (await setup.solana.connection.getTokenAccountBalance(
+                    associatedTokenAccount.address,
+                ))
+                    .value
+                    .amount,
+            );
+
+            expect(currentBalance).to.equal(transferAmount);
+        });
+
+        it("Should be able to transfer tokens from Solana to EVM", async () => {
+            const txHash = await solanaItsProgram.interchainTransfer({
+                payer: setup.solana.wallet.payer.publicKey,
+                sourceAccount: associatedTokenAccount.address,
+                authority: setup.solana.wallet.payer.publicKey,
+                tokenId: arrayify(tokenId),
+                destinationChain: setup.evm.chainName,
+                destinationAddress: arrayify(setup.evm.wallet.address),
+                amount: new BN(transferAmount),
+                mint: solanaToken,
+                gasValue: new BN(gasValue),
+                gasService: setup.solana.gasService,
+                gasConfigPda: setup.solana.gasConfigPda,
+                tokenProgram: TOKEN_2022_PROGRAM_ID,
+            }).rpc();
+
+            const srcGmpDetails = await utils.waitForGmpExecution(
+                txHash,
+                setup.axelar,
+            );
+            const dstGmpDetails = await utils.waitForGmpExecution(
+                srcGmpDetails.executed.transactionHash,
+                setup.axelar,
+            );
+            const evmTx = await setup.evm.provider.getTransaction(
+                dstGmpDetails.executed.transactionHash,
+            );
+
+            await expect(evmTx).to.emit(
+                evmItsContract,
+                "InterchainTransferReceived",
+            ).withNamedArgs({
+                tokenId,
+                amount: transferAmount,
+                sourceChain: setup.solana.chainName,
+            });
+
+            expect(
+                await token.balanceOf(setup.evm.wallet.address),
+            )
+                .to.equal(transferAmount);
+        });
+    });
+
+    describe("Contract call with Token", () => {
+        let memoAssociatedTokenAccount;
+        let solanaMemoProgram;
+        let evmMemoContract;
+
+        // Keep memo shorter than 10 characters, otherwise solana memo program
+        // doesn't log it.
+        const randomSuffix = utils.generateRandomString(2);
+        const memo = "e2e test" + randomSuffix;
+        const [counterPdaPublicKey] = PublicKey.findProgramAddressSync(
+            [gatewayRootPdaPublicKey.toBuffer()],
+            AXELAR_SOLANA_MEMO_PROGRAM_PROGRAM_ID,
+        );
+
+        before(async () => {
+            const evmMemoInfo = utils.getContractInfo(
+                "AxelarMemo",
+                setup.evm.chainName,
+            );
+
+            const solanaMemoInfo = utils.getContractInfo(
+                "axelar_solana_memo_program",
+                setup.solana.chainName,
+            );
+
+            solanaMemoProgram = axelarSolanaMemoProgramProgram({
+                programId: new PublicKey(solanaMemoInfo.address),
+                provider: setup.solana.provider,
+            });
+
+            evmMemoContract = await utils.getEvmContract(
+                setup.evm.wallet,
+                "AxelarMemo",
+                evmMemoInfo.address,
+            );
+
+            // Native Interchain Tokens are always spl-token-2022
+            memoAssociatedTokenAccount = await getOrCreateAssociatedTokenAccount(
+                setup.solana.connection,
+                setup.solana.wallet.payer,
+                solanaToken,
+                solanaMemoProgram.programId,
+                true,
+                null,
+                null,
+                TOKEN_2022_PROGRAM_ID,
+            );
+
+            let mintTx = await token.mint(setup.evm.wallet.address, transferAmount);
+            await mintTx.wait();
+
+            await solanaItsProgram.interchainToken.mint({
+                tokenId: arrayify(tokenId),
+                mint: solanaToken,
+                to: associatedTokenAccount.address,
+                minter: setup.solana.wallet.payer.publicKey,
+                tokenProgram: TOKEN_2022_PROGRAM_ID,
+                amount: new BN(transferAmount),
+            }).rpc();
+        });
+
+        it("Should be able to call Memo contract with tokens from EVM to Solana", async () => {
+            const memoIx = await solanaMemoProgram.methods
+                .processMemo(memo)
+                .accounts({ counterPda: counterPdaPublicKey })
+                .instruction();
+            const executablePayload = new SolanaAxelarExecutablePayload(memoIx, EncodingSchema.ABI);
+            const metadataVersion = 0;
+            const metadata = solidityPack(['uint32', 'bytes'], [metadataVersion, executablePayload.encode()]);
+
+            const tx = await evmItsContract.interchainTransfer(
+                tokenId,
+                setup.solana.chainName,
+                solanaMemoProgram.programId.toBytes(),
+                Math.floor(transferAmount),
+                metadata,
+                gasValue,
+                { value: gasValue },
+            );
+
+            const srcGmpDetails = await utils.waitForGmpExecution(
+                tx.hash,
+                setup.axelar,
+            );
+            await utils.waitForGmpExecution(
+                srcGmpDetails.executed.transactionHash,
+                setup.axelar,
+            );
+
+            const currentBalance = Number(
+                (await setup.solana.connection.getTokenAccountBalance(
+                    memoAssociatedTokenAccount.address,
+                ))
+                    .value
+                    .amount,
+            );
+
+            expect(currentBalance).to.equal(transferAmount);
+        });
+
+        it("Should be able to call Memo contract with tokens from Solana to EVM", async () => {
+            const txHash = await solanaItsProgram.callContractWithInterchainToken({
+                payer: setup.solana.wallet.payer.publicKey,
+                sourceAccount: associatedTokenAccount.address,
+                authority: setup.solana.wallet.payer.publicKey,
+                tokenId: arrayify(tokenId),
+                destinationChain: setup.evm.chainName,
+                destinationAddress: arrayify(evmMemoContract.address),
+                amount: new BN(transferAmount),
+                mint: solanaToken,
+                data: Buffer.from(memo),
+                gasValue: new BN(0),
+                gasService: setup.solana.gasService,
+                gasConfigPda: setup.solana.gasConfigPda,
+                tokenProgram: TOKEN_2022_PROGRAM_ID,
+            }).rpc();
+
+            const srcGmpDetails = await utils.waitForGmpExecution(
+                txHash,
+                setup.axelar,
+            );
+            const dstGmpDetails = await utils.waitForGmpExecution(
+                srcGmpDetails.executed.transactionHash,
+                setup.axelar,
+            );
+            const evmTx = await setup.evm.provider.getTransaction(
+                dstGmpDetails.executed.transactionHash,
+            );
+
+            await expect(evmTx).to.emit(
+                evmMemoContract,
+                "ReceivedMemoWithToken",
+            ).withNamedArgs({
+                sourceChain: setup.solana.chainName,
+                tokenId,
+                amount: transferAmount,
+                memoMessage: memo
+            });
+
+            expect(await token.balanceOf(evmMemoContract.address)).to.equal(transferAmount);
+        });
+    });
+});

--- a/test/its-evm-solana-native-interchain-token.js
+++ b/test/its-evm-solana-native-interchain-token.js
@@ -1,6 +1,7 @@
 const chai = require("chai");
 const solanaWeb3 = require("@solana/web3.js");
 const utils = require("../lib/utils.js");
+const path = require("path");
 const { Buffer } = require("node:buffer");
 
 const { AXELAR_SOLANA_GATEWAY_PROGRAM_ID } = require(
@@ -36,7 +37,9 @@ chai.use(solidity);
 describe("EVM -> Solana Native Interchain Token", function() {
     this.timeout("20m");
 
-    const setup = utils.setupConnections();
+    const fileName = path.parse(__filename).name;
+    const evmKeyEnvVar = utils.toSnakeCaseCapital(fileName);
+    const setup = utils.setupConnections(evmKeyEnvVar);
     const evmItsInfo = utils.getContractInfo(
         "InterchainTokenService",
         setup.evm.chainName,

--- a/test/its-evm-solana-native-interchain-token.js
+++ b/test/its-evm-solana-native-interchain-token.js
@@ -198,7 +198,7 @@ describe("EVM -> Solana Native Interchain Token", function() {
         });
 
         it("Should be able to transfer tokens from Solana to EVM", async () => {
-            const txHash = await solanaItsProgram.interchainTransfer({
+            const tx = await solanaItsProgram.interchainTransfer({
                 payer: setup.solana.wallet.payer.publicKey,
                 sourceAccount: associatedTokenAccount.address,
                 authority: setup.solana.wallet.payer.publicKey,
@@ -211,7 +211,8 @@ describe("EVM -> Solana Native Interchain Token", function() {
                 gasService: setup.solana.gasService,
                 gasConfigPda: setup.solana.gasConfigPda,
                 tokenProgram: TOKEN_2022_PROGRAM_ID,
-            }).rpc();
+            }).transaction();
+            const txHash = await utils.sendSolanaTransaction(setup.solana, tx);
 
             const srcGmpDetails = await utils.waitForGmpExecution(
                 txHash,
@@ -292,14 +293,15 @@ describe("EVM -> Solana Native Interchain Token", function() {
             let mintTx = await token.mint(setup.evm.wallet.address, transferAmount);
             await mintTx.wait();
 
-            await solanaItsProgram.interchainToken.mint({
+            const tx = await solanaItsProgram.interchainToken.mint({
                 tokenId: arrayify(tokenId),
                 mint: solanaToken,
                 to: associatedTokenAccount.address,
                 minter: setup.solana.wallet.payer.publicKey,
                 tokenProgram: TOKEN_2022_PROGRAM_ID,
                 amount: new BN(transferAmount),
-            }).rpc();
+            }).transaction();
+            await utils.sendSolanaTransaction(setup.solana, tx);
         });
 
         it("Should be able to call Memo contract with tokens from EVM to Solana", async () => {
@@ -342,7 +344,7 @@ describe("EVM -> Solana Native Interchain Token", function() {
         });
 
         it("Should be able to call Memo contract with tokens from Solana to EVM", async () => {
-            const txHash = await solanaItsProgram.callContractWithInterchainToken({
+            const tx = await solanaItsProgram.callContractWithInterchainToken({
                 payer: setup.solana.wallet.payer.publicKey,
                 sourceAccount: associatedTokenAccount.address,
                 authority: setup.solana.wallet.payer.publicKey,
@@ -356,7 +358,8 @@ describe("EVM -> Solana Native Interchain Token", function() {
                 gasService: setup.solana.gasService,
                 gasConfigPda: setup.solana.gasConfigPda,
                 tokenProgram: TOKEN_2022_PROGRAM_ID,
-            }).rpc();
+            }).transaction();
+            const txHash = await utils.sendSolanaTransaction(setup.solana, tx);
 
             const srcGmpDetails = await utils.waitForGmpExecution(
                 txHash,

--- a/test/its-evm-solana-native-interchain-token.js
+++ b/test/its-evm-solana-native-interchain-token.js
@@ -35,7 +35,7 @@ const {
 chai.use(solidity);
 
 describe("EVM -> Solana Native Interchain Token", function() {
-    this.timeout("20m");
+    this.timeout("60m");
 
     const fileName = path.parse(__filename).name;
     const evmKeyEnvVar = utils.toSnakeCaseCapital(fileName);

--- a/test/its-solana-evm-canonical-token.js
+++ b/test/its-solana-evm-canonical-token.js
@@ -82,14 +82,14 @@ describe("Solana -> EVM Canonical Interchain Token", function() {
 
     it("Should register the token on Solana and deploy remotely on the EVM chain", async () => {
         tokenId = canonicalInterchainTokenId(token);
-
-        await solanaItsProgram.registerCanonicalInterchainToken({
+        const tx = await solanaItsProgram.registerCanonicalInterchainToken({
             payer: setup.solana.wallet.payer.publicKey,
             mint: token,
             tokenProgram: TOKEN_PROGRAM_ID,
-        }).rpc();
+        }).transaction();
+        await utils.sendSolanaTransaction(setup.solana, tx);
 
-        const txHash = await solanaItsProgram
+        const deployTx = await solanaItsProgram
             .deployRemoteCanonicalInterchainToken({
                 payer: setup.solana.wallet.payer.publicKey,
                 mint: token,
@@ -98,7 +98,8 @@ describe("Solana -> EVM Canonical Interchain Token", function() {
                 gasService: setup.solana.gasService,
                 gasConfigPda: setup.solana.gasConfigPda,
                 tokenProgram: TOKEN_PROGRAM_ID,
-            }).rpc();
+            }).transaction();
+        const txHash = await utils.sendSolanaTransaction(setup.solana, deployTx);
 
         const srcGmpDetails = await utils.waitForGmpExecution(
             txHash,
@@ -125,7 +126,7 @@ describe("Solana -> EVM Canonical Interchain Token", function() {
 
     describe("InterchainTransfer", () => {
         it("Should be able to transfer tokens from Solana to EVM", async () => {
-            const txHash = await solanaItsProgram.interchainTransfer({
+            const tx = await solanaItsProgram.interchainTransfer({
                 payer: setup.solana.wallet.payer.publicKey,
                 sourceAccount: associatedTokenAccount.address,
                 authority: setup.solana.wallet.payer.publicKey,
@@ -138,7 +139,8 @@ describe("Solana -> EVM Canonical Interchain Token", function() {
                 gasService: setup.solana.gasService,
                 gasConfigPda: setup.solana.gasConfigPda,
                 tokenProgram: TOKEN_PROGRAM_ID,
-            }).rpc();
+            }).transaction();
+            const txHash = await utils.sendSolanaTransaction(setup.solana, tx);
 
             const srcGmpDetails = await utils.waitForGmpExecution(
                 txHash,

--- a/test/its-solana-evm-canonical-token.js
+++ b/test/its-solana-evm-canonical-token.js
@@ -1,6 +1,7 @@
 const chai = require("chai");
 const solanaWeb3 = require("@solana/web3.js");
 const utils = require("../lib/utils.js");
+const path = require("path");
 const { Buffer } = require("node:buffer");
 
 const { AXELAR_SOLANA_GATEWAY_PROGRAM_ID } = require(
@@ -26,7 +27,9 @@ chai.use(solidity);
 describe("Solana -> EVM Canonical Interchain Token", function() {
     this.timeout("20m");
 
-    const setup = utils.setupConnections();
+    const fileName = path.parse(__filename).name;
+    const evmKeyEnvVar = utils.toSnakeCaseCapital(fileName);
+    const setup = utils.setupConnections(evmKeyEnvVar);
     const evmItsInfo = utils.getContractInfo(
         "InterchainTokenService",
         setup.evm.chainName,

--- a/test/its-solana-evm-canonical-token.js
+++ b/test/its-solana-evm-canonical-token.js
@@ -1,0 +1,208 @@
+const chai = require("chai");
+const solanaWeb3 = require("@solana/web3.js");
+const utils = require("../lib/utils.js");
+const { Buffer } = require("node:buffer");
+
+const { AXELAR_SOLANA_GATEWAY_PROGRAM_ID } = require(
+    "@eiger/solana-axelar/anchor/gateway",
+);
+const { BN } = require("@coral-xyz/anchor");
+const {
+    ItsInstructions,
+    canonicalInterchainTokenId,
+} = require(
+    "@eiger/solana-axelar/its"
+);
+const { PublicKey } = solanaWeb3;
+const { TOKEN_PROGRAM_ID } = require(
+    "@solana/spl-token",
+);
+const { expect } = chai;
+const { solidity } = require("ethereum-waffle");
+const { utils: { hexlify, arrayify } } = require("ethers");
+
+chai.use(solidity);
+
+describe("Solana -> EVM Canonical Interchain Token", function() {
+    this.timeout("20m");
+
+    const setup = utils.setupConnections();
+    const evmItsInfo = utils.getContractInfo(
+        "InterchainTokenService",
+        setup.evm.chainName,
+    );
+    const solanaItsInfo = utils.getContractInfo(
+        "axelar_solana_its",
+        setup.solana.chainName,
+    );
+
+    const [gatewayRootPdaPublicKey] = PublicKey.findProgramAddressSync(
+        [Buffer.from("gateway")],
+        AXELAR_SOLANA_GATEWAY_PROGRAM_ID,
+    );
+
+    const name = "MyToken";
+    const symbol = "MT";
+    const decimals = 6;
+    const transferAmount = 1e6;
+    const gasValue = 2500000;
+
+    let solanaItsProgram;
+    let evmItsContract;
+
+    let token;
+    let tokenId;
+    let associatedTokenAccount;
+    let _metadataPda;
+
+    before(async () => {
+        solanaItsProgram = new ItsInstructions(
+            new PublicKey(solanaItsInfo.address),
+            gatewayRootPdaPublicKey,
+            setup.solana.provider,
+        );
+        evmItsContract = await utils.getEvmContract(
+            setup.evm.wallet,
+            "InterchainTokenService",
+            evmItsInfo.address,
+        );
+
+        [token, associatedTokenAccount, _metadataPda] = await utils
+            .setupSolanaMint(
+                setup.solana,
+                name,
+                symbol,
+                decimals,
+                transferAmount,
+            );
+    });
+
+    it("Should register the token on Solana and deploy remotely on the EVM chain", async () => {
+        tokenId = canonicalInterchainTokenId(token);
+
+        await solanaItsProgram.registerCanonicalInterchainToken({
+            payer: setup.solana.wallet.payer.publicKey,
+            mint: token,
+            tokenProgram: TOKEN_PROGRAM_ID,
+        }).rpc();
+
+        const txHash = await solanaItsProgram
+            .deployRemoteCanonicalInterchainToken({
+                payer: setup.solana.wallet.payer.publicKey,
+                mint: token,
+                destinationChain: setup.evm.chainName,
+                gasValue: new BN(gasValue),
+                gasService: setup.solana.gasService,
+                gasConfigPda: setup.solana.gasConfigPda,
+                tokenProgram: TOKEN_PROGRAM_ID,
+            }).rpc();
+
+        const srcGmpDetails = await utils.waitForGmpExecution(
+            txHash,
+            setup.axelar,
+        );
+        const dstGmpDetails = await utils.waitForGmpExecution(
+            srcGmpDetails.executed.transactionHash,
+            setup.axelar,
+        );
+        const evmTx = await setup.evm.provider.getTransaction(
+            dstGmpDetails.executed.transactionHash,
+        );
+
+        await expect(evmTx).to.emit(
+            evmItsContract,
+            "InterchainTokenDeployed",
+        ).withNamedArgs({
+            tokenId: hexlify(tokenId),
+            name,
+            symbol,
+            decimals,
+        });
+    });
+
+    describe("InterchainTransfer", () => {
+        it("Should be able to transfer tokens from Solana to EVM", async () => {
+            const txHash = await solanaItsProgram.interchainTransfer({
+                payer: setup.solana.wallet.payer.publicKey,
+                sourceAccount: associatedTokenAccount.address,
+                authority: setup.solana.wallet.payer.publicKey,
+                tokenId,
+                destinationChain: setup.evm.chainName,
+                destinationAddress: arrayify(setup.evm.wallet.address),
+                amount: new BN(transferAmount),
+                mint: token,
+                gasValue: new BN(gasValue),
+                gasService: setup.solana.gasService,
+                gasConfigPda: setup.solana.gasConfigPda,
+                tokenProgram: TOKEN_PROGRAM_ID,
+            }).rpc();
+
+            const srcGmpDetails = await utils.waitForGmpExecution(
+                txHash,
+                setup.axelar,
+            );
+            const dstGmpDetails = await utils.waitForGmpExecution(
+                srcGmpDetails.executed.transactionHash,
+                setup.axelar,
+            );
+            const evmTx = await setup.evm.provider.getTransaction(
+                dstGmpDetails.executed.transactionHash,
+            );
+
+            await expect(evmTx).to.emit(
+                evmItsContract,
+                "InterchainTransferReceived",
+            ).withNamedArgs({
+                tokenId: hexlify(tokenId),
+                amount: transferAmount,
+                sourceChain: setup.solana.chainName,
+            });
+
+            const evmTokenAddress = await evmItsContract
+                .registeredTokenAddress(
+                    hexlify(tokenId),
+                );
+            const evmTokenContract = await utils.getEvmContract(
+                setup.evm.wallet,
+                "InterchainToken",
+                evmTokenAddress,
+            );
+
+            expect(
+                await evmTokenContract.balanceOf(setup.evm.wallet.address),
+            )
+                .to.equal(transferAmount);
+        });
+
+        it("Should be able to transfer tokens from EVM to Solana", async () => {
+            const tx = await evmItsContract.interchainTransfer(
+                hexlify(tokenId),
+                setup.solana.chainName,
+                associatedTokenAccount.address.toBytes(),
+                Math.floor(transferAmount),
+                "0x",
+                gasValue,
+                { value: gasValue },
+            );
+
+            const srcGmpDetails = await utils.waitForGmpExecution(
+                tx.hash,
+                setup.axelar,
+            );
+            await utils.waitForGmpExecution(
+                srcGmpDetails.executed.transactionHash,
+                setup.axelar,
+            );
+
+            const currentBalance = Number(
+                (await setup.solana.connection.getTokenAccountBalance(
+                    associatedTokenAccount.address,
+                ))
+                    .value
+                    .amount,
+            );
+
+            expect(currentBalance).to.equal(transferAmount);
+        });
+    });
+});

--- a/test/its-solana-evm-canonical-token.js
+++ b/test/its-solana-evm-canonical-token.js
@@ -25,7 +25,7 @@ const { utils: { hexlify, arrayify } } = require("ethers");
 chai.use(solidity);
 
 describe("Solana -> EVM Canonical Interchain Token", function() {
-    this.timeout("20m");
+    this.timeout("60m");
 
     const fileName = path.parse(__filename).name;
     const evmKeyEnvVar = utils.toSnakeCaseCapital(fileName);

--- a/test/its-solana-evm-custom-token.js
+++ b/test/its-solana-evm-custom-token.js
@@ -1,0 +1,252 @@
+const chai = require("chai");
+const solanaWeb3 = require("@solana/web3.js");
+const utils = require("../lib/utils.js");
+const { Buffer } = require("node:buffer");
+
+const { AXELAR_SOLANA_GATEWAY_PROGRAM_ID } = require(
+    "@eiger/solana-axelar/anchor/gateway",
+);
+const { BN } = require("@coral-xyz/anchor");
+const {
+    ItsInstructions,
+    TokenManagerType,
+    linkedTokenId,
+} = require(
+    "@eiger/solana-axelar/its"
+);
+const { PublicKey } = solanaWeb3;
+const { TOKEN_PROGRAM_ID } = require(
+    "@solana/spl-token",
+);
+const { expect } = chai;
+const { solidity } = require("ethereum-waffle");
+const { utils: { hexlify, arrayify } } = require("ethers");
+
+chai.use(solidity);
+
+describe("Solana -> EVM Existing Custom Token", function() {
+    this.timeout("20m");
+
+    const setup = utils.setupConnections();
+    const evmItsInfo = utils.getContractInfo(
+        "InterchainTokenService",
+        setup.evm.chainName,
+    );
+    const solanaItsInfo = utils.getContractInfo(
+        "axelar_solana_its",
+        setup.solana.chainName,
+    );
+
+    const [gatewayRootPdaPublicKey] = PublicKey.findProgramAddressSync(
+        [Buffer.from("gateway")],
+        AXELAR_SOLANA_GATEWAY_PROGRAM_ID,
+    );
+
+    const name = "MyToken";
+    const symbol = "MT";
+    const decimals = 6;
+    const transferAmount = 1e6;
+    const gasValue = 2500000;
+    const salt = utils.getRandomBytes32();
+    const tokenId = linkedTokenId(
+        setup.solana.wallet.payer.publicKey,
+        salt,
+    );
+
+    let solanaItsProgram;
+    let evmItsContract;
+
+    let token;
+    let associatedTokenAccount;
+    let evmToken;
+
+    before(async () => {
+        solanaItsProgram = new ItsInstructions(
+            new PublicKey(solanaItsInfo.address),
+            gatewayRootPdaPublicKey,
+            setup.solana.provider,
+        );
+        evmItsContract = await utils.getEvmContract(
+            setup.evm.wallet,
+            "InterchainTokenService",
+            evmItsInfo.address,
+        );
+
+        [token, associatedTokenAccount, _metadataPda] = await utils
+            .setupSolanaMint(
+                setup.solana,
+                name,
+                symbol,
+                decimals,
+                transferAmount,
+            );
+
+        const solanaMetadataTxHash = await solanaItsProgram
+            .registerTokenMetadata({
+                payer: setup.solana.wallet.payer.publicKey,
+                mint: token,
+                tokenProgram: TOKEN_PROGRAM_ID,
+                gasValue: new BN(0),
+                gasService: setup.solana.gasService,
+                gasConfigPda: setup.solana.gasConfigPda,
+            }).rpc();
+
+        evmToken = await utils.deployEvmContract(
+            setup.evm.wallet,
+            "CustomTestToken",
+            [
+                name,
+                symbol,
+                decimals,
+            ],
+        );
+
+        const evmMetadataTx = await evmItsContract.registerTokenMetadata(
+            evmToken.address,
+            gasValue,
+            {
+                value: gasValue,
+            },
+        );
+        await evmMetadataTx.wait();
+
+        const evmTokenManagerAddress = await evmItsContract
+            .tokenManagerAddress(tokenId);
+        await evmToken.addMinter(evmTokenManagerAddress);
+
+        await utils.waitForGmpExecution(
+            evmMetadataTx.hash,
+            setup.axelar,
+        );
+
+        await utils.waitForGmpExecution(
+            solanaMetadataTxHash,
+            setup.axelar,
+        );
+    });
+
+    it("Should register the token on Solana and deploy remotely on the EVM chain", async () => {
+        await solanaItsProgram
+            .registerCustomToken({
+                payer: setup.solana.wallet.payer.publicKey,
+                salt,
+                mint: token,
+                tokenManagerType: TokenManagerType.MintBurn,
+                tokenProgram: TOKEN_PROGRAM_ID,
+                operator: setup.solana.wallet.payer.publicKey,
+            }).rpc();
+
+        await solanaItsProgram.tokenManager.handOverMintAuthority({
+            payer: setup.solana.wallet.payer.publicKey,
+            tokenId,
+            mint: token,
+            TOKEN_PROGRAM_ID,
+        }).rpc();
+
+        const txHash = await solanaItsProgram.linkToken({
+            payer: setup.solana.wallet.payer.publicKey,
+            salt,
+            destinationChain: setup.evm.chainName,
+            destinationTokenAddress: arrayify(evmToken.address),
+            tokenManagerType: TokenManagerType.MintBurn,
+            linkParams: arrayify(setup.evm.wallet.address),
+            gasValue: new BN(0),
+            gasService: setup.solana.gasService,
+            gasConfigPda: setup.solana.gasConfigPda,
+            tokenProgram: TOKEN_PROGRAM_ID,
+        }).rpc();
+
+        const srcGmpDetails = await utils.waitForGmpExecution(
+            txHash,
+            setup.axelar,
+        );
+        const dstGmpDetails = await utils.waitForGmpExecution(
+            srcGmpDetails.executed.transactionHash,
+            setup.axelar,
+        );
+        const evmTx = await setup.evm.provider.getTransaction(
+            dstGmpDetails.executed.transactionHash,
+        );
+
+        await expect(evmTx).to.emit(
+            evmItsContract,
+            "TokenManagerDeployed",
+        ).withNamedArgs({
+            tokenId: hexlify(tokenId),
+            tokenManagerType: TokenManagerType.MintBurn,
+        });
+    });
+
+    describe("InterchainTransfer", () => {
+        it("Should be able to transfer tokens from Solana to EVM", async () => {
+            const txHash = await solanaItsProgram.interchainTransfer({
+                payer: setup.solana.wallet.payer.publicKey,
+                sourceAccount: associatedTokenAccount.address,
+                authority: setup.solana.wallet.payer.publicKey,
+                tokenId,
+                destinationChain: setup.evm.chainName,
+                destinationAddress: arrayify(setup.evm.wallet.address),
+                amount: new BN(transferAmount),
+                mint: token,
+                gasValue: new BN(0),
+                gasService: setup.solana.gasService,
+                gasConfigPda: setup.solana.gasConfigPda,
+                tokenProgram: TOKEN_PROGRAM_ID,
+            }).rpc();
+
+            const srcGmpDetails = await utils.waitForGmpExecution(
+                txHash,
+                setup.axelar,
+            );
+            const dstGmpDetails = await utils.waitForGmpExecution(
+                srcGmpDetails.executed.transactionHash,
+                setup.axelar,
+            );
+            const evmTx = await setup.evm.provider.getTransaction(
+                dstGmpDetails.executed.transactionHash,
+            );
+
+            await expect(evmTx).to.emit(
+                evmItsContract,
+                "InterchainTransferReceived",
+            ).withNamedArgs({
+                tokenId: hexlify(tokenId),
+                amount: transferAmount,
+                sourceChain: setup.solana.chainName,
+            });
+
+            expect(await evmToken.balanceOf(setup.evm.wallet.address)).to.equal(transferAmount);
+        });
+
+        it("Should be able to transfer tokens from EVM to Solana", async () => {
+            const tx = await evmItsContract.interchainTransfer(
+                hexlify(tokenId),
+                setup.solana.chainName,
+                associatedTokenAccount.address.toBytes(),
+                Math.floor(transferAmount),
+                "0x",
+                gasValue,
+                { value: gasValue },
+            );
+
+            const srcGmpDetails = await utils.waitForGmpExecution(
+                tx.hash,
+                setup.axelar,
+            );
+            await utils.waitForGmpExecution(
+                srcGmpDetails.executed.transactionHash,
+                setup.axelar,
+            );
+
+            const currentBalance = Number(
+                (await setup.solana.connection.getTokenAccountBalance(
+                    associatedTokenAccount.address,
+                ))
+                    .value
+                    .amount,
+            );
+
+            expect(currentBalance).to.equal(transferAmount);
+        });
+    });
+});

--- a/test/its-solana-evm-custom-token.js
+++ b/test/its-solana-evm-custom-token.js
@@ -1,6 +1,7 @@
 const chai = require("chai");
 const solanaWeb3 = require("@solana/web3.js");
 const utils = require("../lib/utils.js");
+const path = require("path");
 const { Buffer } = require("node:buffer");
 
 const { AXELAR_SOLANA_GATEWAY_PROGRAM_ID } = require(
@@ -27,7 +28,9 @@ chai.use(solidity);
 describe("Solana -> EVM Existing Custom Token", function() {
     this.timeout("20m");
 
-    const setup = utils.setupConnections();
+    const fileName = path.parse(__filename).name;
+    const evmKeyEnvVar = utils.toSnakeCaseCapital(fileName);
+    const setup = utils.setupConnections(evmKeyEnvVar);
     const evmItsInfo = utils.getContractInfo(
         "InterchainTokenService",
         setup.evm.chainName,

--- a/test/its-solana-evm-custom-token.js
+++ b/test/its-solana-evm-custom-token.js
@@ -26,7 +26,7 @@ const { utils: { hexlify, arrayify } } = require("ethers");
 chai.use(solidity);
 
 describe("Solana -> EVM Existing Custom Token", function() {
-    this.timeout("20m");
+    this.timeout("60m");
 
     const fileName = path.parse(__filename).name;
     const evmKeyEnvVar = utils.toSnakeCaseCapital(fileName);

--- a/test/its-solana-evm-native-interchain-token.js
+++ b/test/its-solana-evm-native-interchain-token.js
@@ -34,7 +34,7 @@ const { utils: { hexlify, arrayify, solidityPack } } = require("ethers");
 chai.use(solidity);
 
 describe("Solana -> EVM Native Interchain Token", function() {
-    this.timeout("20m");
+    this.timeout("60m");
 
     const fileName = path.parse(__filename).name;
     const evmKeyEnvVar = utils.toSnakeCaseCapital(fileName);

--- a/test/its-solana-evm-native-interchain-token.js
+++ b/test/its-solana-evm-native-interchain-token.js
@@ -1,5 +1,6 @@
 const chai = require("chai");
 const solanaWeb3 = require("@solana/web3.js");
+const path = require("path");
 const { getOrCreateAssociatedTokenAccount } = require(
     "@solana/spl-token",
 );
@@ -35,7 +36,9 @@ chai.use(solidity);
 describe("Solana -> EVM Native Interchain Token", function() {
     this.timeout("20m");
 
-    const setup = utils.setupConnections();
+    const fileName = path.parse(__filename).name;
+    const evmKeyEnvVar = utils.toSnakeCaseCapital(fileName);
+    const setup = utils.setupConnections(evmKeyEnvVar);
     const evmItsInfo = utils.getContractInfo(
         "InterchainTokenService",
         setup.evm.chainName,

--- a/test/its-solana-evm-native-interchain-token.js
+++ b/test/its-solana-evm-native-interchain-token.js
@@ -93,24 +93,26 @@ describe("Solana -> EVM Native Interchain Token", function() {
             tokenId,
         );
 
-        await solanaItsProgram.deployInterchainToken({
+        const deployTx = await solanaItsProgram.deployInterchainToken({
             payer: setup.solana.wallet.payer.publicKey,
             salt: Array.from(salt),
             name,
             symbol,
             decimals,
             minter: setup.solana.wallet.payer.publicKey,
-        }).rpc();
+        }).transaction();
+        await utils.sendSolanaTransaction(setup.solana, deployTx);
 
-        await solanaItsProgram.approveDeployRemoteInterchainToken({
+        const approveTx = await solanaItsProgram.approveDeployRemoteInterchainToken({
             payer: setup.solana.wallet.payer.publicKey,
             deployer: setup.solana.wallet.payer.publicKey,
             salt: Array.from(salt),
             destinationChain: setup.evm.chainName,
             destinationMinter: arrayify(setup.evm.wallet.address),
-        }).rpc();
+        }).transaction();
+        await utils.sendSolanaTransaction(setup.solana, approveTx);
 
-        const txHash = await solanaItsProgram.deployRemoteInterchainTokenWithMinter({
+        const tx = await solanaItsProgram.deployRemoteInterchainTokenWithMinter({
             payer: setup.solana.wallet.payer.publicKey,
             salt: Array.from(salt),
             minter: setup.solana.wallet.payer.publicKey,
@@ -119,7 +121,8 @@ describe("Solana -> EVM Native Interchain Token", function() {
             gasValue: new BN(gasValue),
             gasService: setup.solana.gasService,
             gasConfigPda: setup.solana.gasConfigPda,
-        }).rpc();
+        }).transaction();
+        const txHash = await utils.sendSolanaTransaction(setup.solana, tx);
 
         const srcGmpDetails = await utils.waitForGmpExecution(
             txHash,
@@ -173,18 +176,19 @@ describe("Solana -> EVM Native Interchain Token", function() {
                 );
 
             // Minting needs to go through ITS
-            await solanaItsProgram.interchainToken.mint({
+            const mintTx = await solanaItsProgram.interchainToken.mint({
                 tokenId,
                 mint: token,
                 to: associatedTokenAccount.address,
                 minter: setup.solana.wallet.payer.publicKey,
                 tokenProgram: TOKEN_2022_PROGRAM_ID,
                 amount: new BN(transferAmount),
-            }).rpc();
+            }).transaction();
+            await utils.sendSolanaTransaction(setup.solana, mintTx);
         });
 
         it("Should be able to transfer tokens from Solana to EVM", async () => {
-            const txHash = await solanaItsProgram.interchainTransfer({
+            const tx = await solanaItsProgram.interchainTransfer({
                 payer: setup.solana.wallet.payer.publicKey,
                 sourceAccount: associatedTokenAccount.address,
                 authority: setup.solana.wallet.payer.publicKey,
@@ -197,7 +201,8 @@ describe("Solana -> EVM Native Interchain Token", function() {
                 gasService: setup.solana.gasService,
                 gasConfigPda: setup.solana.gasConfigPda,
                 tokenProgram: TOKEN_2022_PROGRAM_ID,
-            }).rpc();
+            }).transaction();
+            const txHash = await utils.sendSolanaTransaction(setup.solana, tx);
 
             const srcGmpDetails = await utils.waitForGmpExecution(
                 txHash,
@@ -275,14 +280,15 @@ describe("Solana -> EVM Native Interchain Token", function() {
 
         before(async () => {
             // Minting needs to go through ITS
-            await solanaItsProgram.interchainToken.mint({
+            const mintTx = await solanaItsProgram.interchainToken.mint({
                 tokenId,
                 mint: token,
                 to: associatedTokenAccount.address,
                 minter: setup.solana.wallet.payer.publicKey,
                 tokenProgram: TOKEN_2022_PROGRAM_ID,
                 amount: new BN(transferAmount),
-            }).rpc();
+            }).transaction();
+            await utils.sendSolanaTransaction(setup.solana, mintTx);
 
             const evmMemoInfo = utils.getContractInfo(
                 "AxelarMemo",
@@ -319,7 +325,7 @@ describe("Solana -> EVM Native Interchain Token", function() {
         });
 
         it("Should be able to call Memo contract with tokens from Solana to EVM", async () => {
-            const txHash = await solanaItsProgram.callContractWithInterchainToken({
+            const tx = await solanaItsProgram.callContractWithInterchainToken({
                 payer: setup.solana.wallet.payer.publicKey,
                 sourceAccount: associatedTokenAccount.address,
                 authority: setup.solana.wallet.payer.publicKey,
@@ -333,7 +339,8 @@ describe("Solana -> EVM Native Interchain Token", function() {
                 gasService: setup.solana.gasService,
                 gasConfigPda: setup.solana.gasConfigPda,
                 tokenProgram: TOKEN_2022_PROGRAM_ID,
-            }).rpc();
+            }).transaction();
+            const txHash = await utils.sendSolanaTransaction(setup.solana, tx);
 
             const srcGmpDetails = await utils.waitForGmpExecution(
                 txHash,

--- a/test/its-solana-evm-native-interchain-token.js
+++ b/test/its-solana-evm-native-interchain-token.js
@@ -1,0 +1,416 @@
+const chai = require("chai");
+const solanaWeb3 = require("@solana/web3.js");
+const { getOrCreateAssociatedTokenAccount } = require(
+    "@solana/spl-token",
+);
+const utils = require("../lib/utils.js");
+const { Buffer } = require("node:buffer");
+
+const { AXELAR_SOLANA_GATEWAY_PROGRAM_ID } = require(
+    "@eiger/solana-axelar/anchor/gateway",
+);
+const {
+    axelarSolanaMemoProgramProgram,
+    AXELAR_SOLANA_MEMO_PROGRAM_PROGRAM_ID,
+} = require("@eiger/solana-axelar/anchor/memo-program");
+const { BN } = require("@coral-xyz/anchor");
+const { SolanaAxelarExecutablePayload, EncodingSchema } = require("@eiger/solana-axelar/executable");
+const {
+    ItsInstructions,
+    interchainTokenId,
+    findInterchainTokenPda,
+} = require(
+    "@eiger/solana-axelar/its",
+);
+const { PublicKey } = solanaWeb3;
+const { TOKEN_2022_PROGRAM_ID } = require(
+    "@solana/spl-token",
+);
+const { expect } = chai;
+const { solidity } = require("ethereum-waffle");
+const { utils: { hexlify, arrayify, solidityPack } } = require("ethers");
+
+chai.use(solidity);
+
+describe("Solana -> EVM Native Interchain Token", function() {
+    this.timeout("20m");
+
+    const setup = utils.setupConnections();
+    const evmItsInfo = utils.getContractInfo(
+        "InterchainTokenService",
+        setup.evm.chainName,
+    );
+    const solanaItsInfo = utils.getContractInfo(
+        "axelar_solana_its",
+        setup.solana.chainName,
+    );
+
+    const [gatewayRootPdaPublicKey] = PublicKey.findProgramAddressSync(
+        [Buffer.from("gateway")],
+        AXELAR_SOLANA_GATEWAY_PROGRAM_ID,
+    );
+
+    const name = "MyInterchainToken";
+    const symbol = "MIT";
+    const decimals = 6;
+    const transferAmount = 100;
+    const gasValue = 2500000;
+    const salt = utils.getRandomBytes32();
+
+    let solanaItsProgram;
+    let evmItsContract;
+
+    let token;
+    let tokenId;
+    let associatedTokenAccount;
+
+    let evmTokenContract;
+    let evmTokenAddress;
+
+    before(async () => {
+        solanaItsProgram = new ItsInstructions(
+            new PublicKey(solanaItsInfo.address),
+            gatewayRootPdaPublicKey,
+            setup.solana.provider,
+        );
+        evmItsContract = await utils.getEvmContract(
+            setup.evm.wallet,
+            "InterchainTokenService",
+            evmItsInfo.address,
+        );
+    });
+
+    it("Should register the token on Solana and deploy remotely on the EVM chain", async () => {
+        tokenId = interchainTokenId(
+            setup.solana.wallet.payer.publicKey,
+            salt,
+        );
+        [token] = findInterchainTokenPda(
+            solanaItsProgram.itsRootPda,
+            tokenId,
+        );
+
+        await solanaItsProgram.deployInterchainToken({
+            payer: setup.solana.wallet.payer.publicKey,
+            salt: Array.from(salt),
+            name,
+            symbol,
+            decimals,
+            minter: setup.solana.wallet.payer.publicKey,
+        }).rpc();
+
+        await solanaItsProgram.approveDeployRemoteInterchainToken({
+            payer: setup.solana.wallet.payer.publicKey,
+            deployer: setup.solana.wallet.payer.publicKey,
+            salt: Array.from(salt),
+            destinationChain: setup.evm.chainName,
+            destinationMinter: arrayify(setup.evm.wallet.address),
+        }).rpc();
+
+        const txHash = await solanaItsProgram.deployRemoteInterchainTokenWithMinter({
+            payer: setup.solana.wallet.payer.publicKey,
+            salt: Array.from(salt),
+            minter: setup.solana.wallet.payer.publicKey,
+            destinationChain: setup.evm.chainName,
+            destinationMinter: arrayify(setup.evm.wallet.address),
+            gasValue: new BN(gasValue),
+            gasService: setup.solana.gasService,
+            gasConfigPda: setup.solana.gasConfigPda,
+        }).rpc();
+
+        const srcGmpDetails = await utils.waitForGmpExecution(
+            txHash,
+            setup.axelar,
+        );
+        const dstGmpDetails = await utils.waitForGmpExecution(
+            srcGmpDetails.executed.transactionHash,
+            setup.axelar,
+        );
+        const evmTx = await setup.evm.provider.getTransaction(
+            dstGmpDetails.executed.transactionHash,
+        );
+
+        await expect(evmTx).to.emit(
+            evmItsContract,
+            "InterchainTokenDeployed",
+        ).withNamedArgs({
+            tokenId: hexlify(tokenId),
+            name,
+            symbol,
+            decimals,
+        });
+
+
+    });
+
+    describe("InterchainTransfer", () => {
+        before(async () => {
+            evmTokenAddress = await evmItsContract
+                .registeredTokenAddress(
+                    hexlify(tokenId),
+                );
+
+            evmTokenContract = await utils.getEvmContract(
+                setup.evm.wallet,
+                "InterchainToken",
+                evmTokenAddress,
+            );
+
+            associatedTokenAccount =
+                // Native Interchain Tokens are always spl-token-2022
+                await getOrCreateAssociatedTokenAccount(
+                    setup.solana.connection,
+                    setup.solana.wallet.payer,
+                    token,
+                    setup.solana.wallet.payer.publicKey,
+                    false,
+                    null,
+                    null,
+                    TOKEN_2022_PROGRAM_ID,
+                );
+
+            // Minting needs to go through ITS
+            await solanaItsProgram.interchainToken.mint({
+                tokenId,
+                mint: token,
+                to: associatedTokenAccount.address,
+                minter: setup.solana.wallet.payer.publicKey,
+                tokenProgram: TOKEN_2022_PROGRAM_ID,
+                amount: new BN(transferAmount),
+            }).rpc();
+        });
+
+        it("Should be able to transfer tokens from Solana to EVM", async () => {
+            const txHash = await solanaItsProgram.interchainTransfer({
+                payer: setup.solana.wallet.payer.publicKey,
+                sourceAccount: associatedTokenAccount.address,
+                authority: setup.solana.wallet.payer.publicKey,
+                tokenId,
+                destinationChain: setup.evm.chainName,
+                destinationAddress: arrayify(setup.evm.wallet.address),
+                amount: new BN(transferAmount),
+                mint: token,
+                gasValue: new BN(gasValue),
+                gasService: setup.solana.gasService,
+                gasConfigPda: setup.solana.gasConfigPda,
+                tokenProgram: TOKEN_2022_PROGRAM_ID,
+            }).rpc();
+
+            const srcGmpDetails = await utils.waitForGmpExecution(
+                txHash,
+                setup.axelar,
+            );
+            const dstGmpDetails = await utils.waitForGmpExecution(
+                srcGmpDetails.executed.transactionHash,
+                setup.axelar,
+            );
+            const evmTx = await setup.evm.provider.getTransaction(
+                dstGmpDetails.executed.transactionHash,
+            );
+
+            await expect(evmTx).to.emit(
+                evmItsContract,
+                "InterchainTransferReceived",
+            ).withNamedArgs({
+                tokenId: hexlify(tokenId),
+                amount: transferAmount,
+                sourceChain: setup.solana.chainName,
+            });
+
+            expect(
+                await evmTokenContract.balanceOf(setup.evm.wallet.address),
+            )
+                .to.equal(transferAmount);
+        });
+
+        it("Should be able to transfer tokens from EVM to Solana", async () => {
+            const tx = await evmItsContract.interchainTransfer(
+                hexlify(tokenId),
+                setup.solana.chainName,
+                associatedTokenAccount.address.toBytes(),
+                Math.floor(transferAmount),
+                "0x",
+                gasValue,
+                { value: gasValue },
+            );
+
+            const srcGmpDetails = await utils.waitForGmpExecution(
+                tx.hash,
+                setup.axelar,
+            );
+            await utils.waitForGmpExecution(
+                srcGmpDetails.executed.transactionHash,
+                setup.axelar,
+            );
+
+            const expectedBalance = transferAmount;
+            const currentBalance = Number(
+                (await setup.solana.connection.getTokenAccountBalance(
+                    associatedTokenAccount.address,
+                ))
+                    .value
+                    .amount,
+            );
+
+            expect(currentBalance).to.equal(expectedBalance);
+        });
+    });
+
+    describe("Contract call with Token", () => {
+        let memoAssociatedTokenAccount;
+        let solanaMemoProgram;
+        let evmMemoContract;
+
+        // Keep memo shorter than 10 characters, otherwise solana memo program
+        // doesn't log it.
+        const randomSuffix = utils.generateRandomString(2);
+        const memo = "e2e test" + randomSuffix;
+        const [counterPdaPublicKey] = PublicKey.findProgramAddressSync(
+            [gatewayRootPdaPublicKey.toBuffer()],
+            AXELAR_SOLANA_MEMO_PROGRAM_PROGRAM_ID,
+        );
+
+        before(async () => {
+            // Minting needs to go through ITS
+            await solanaItsProgram.interchainToken.mint({
+                tokenId,
+                mint: token,
+                to: associatedTokenAccount.address,
+                minter: setup.solana.wallet.payer.publicKey,
+                tokenProgram: TOKEN_2022_PROGRAM_ID,
+                amount: new BN(transferAmount),
+            }).rpc();
+
+            const evmMemoInfo = utils.getContractInfo(
+                "AxelarMemo",
+                setup.evm.chainName,
+            );
+
+            const solanaMemoInfo = utils.getContractInfo(
+                "axelar_solana_memo_program",
+                setup.solana.chainName,
+            );
+
+            solanaMemoProgram = axelarSolanaMemoProgramProgram({
+                programId: new PublicKey(solanaMemoInfo.address),
+                provider: setup.solana.provider,
+            });
+
+            evmMemoContract = await utils.getEvmContract(
+                setup.evm.wallet,
+                "AxelarMemo",
+                evmMemoInfo.address,
+            );
+
+            // Native Interchain Tokens are always spl-token-2022
+            memoAssociatedTokenAccount = await getOrCreateAssociatedTokenAccount(
+                setup.solana.connection,
+                setup.solana.wallet.payer,
+                token,
+                solanaMemoProgram.programId,
+                true,
+                null,
+                null,
+                TOKEN_2022_PROGRAM_ID,
+            );
+        });
+
+        it("Should be able to call Memo contract with tokens from Solana to EVM", async () => {
+            const txHash = await solanaItsProgram.callContractWithInterchainToken({
+                payer: setup.solana.wallet.payer.publicKey,
+                sourceAccount: associatedTokenAccount.address,
+                authority: setup.solana.wallet.payer.publicKey,
+                tokenId,
+                destinationChain: setup.evm.chainName,
+                destinationAddress: arrayify(evmMemoContract.address),
+                amount: new BN(transferAmount),
+                mint: token,
+                data: Buffer.from(memo),
+                gasValue: new BN(gasValue),
+                gasService: setup.solana.gasService,
+                gasConfigPda: setup.solana.gasConfigPda,
+                tokenProgram: TOKEN_2022_PROGRAM_ID,
+            }).rpc();
+
+            const srcGmpDetails = await utils.waitForGmpExecution(
+                txHash,
+                setup.axelar,
+            );
+            const dstGmpDetails = await utils.waitForGmpExecution(
+                srcGmpDetails.executed.transactionHash,
+                setup.axelar,
+            );
+            const evmTx = await setup.evm.provider.getTransaction(
+                dstGmpDetails.executed.transactionHash,
+            );
+
+            await expect(evmTx).to.emit(
+                evmMemoContract,
+                "ReceivedMemoWithToken",
+            ).withNamedArgs({
+                sourceChain: setup.solana.chainName,
+                tokenId: hexlify(tokenId),
+                amount: transferAmount,
+                memoMessage: memo
+            });
+
+            expect(
+                await evmTokenContract.balanceOf(evmMemoContract.address),
+            )
+                .to.equal(transferAmount);
+        });
+
+
+        it("Should be able to call Memo contract with tokens from EVM to Solana", async () => {
+            const evmTokenAddress = await evmItsContract
+                .registeredTokenAddress(
+                    hexlify(tokenId),
+                );
+            const evmTokenContract = await utils.getEvmContract(
+                setup.evm.wallet,
+                "InterchainToken",
+                evmTokenAddress,
+            );
+
+            let evmCall = await evmTokenContract.mint(setup.evm.wallet.address, transferAmount);
+            evmCall = await evmCall.wait();
+
+            const memoIx = await solanaMemoProgram.methods
+                .processMemo(memo)
+                .accounts({ counterPda: counterPdaPublicKey })
+                .instruction();
+            const executablePayload = new SolanaAxelarExecutablePayload(memoIx, EncodingSchema.BORSH);
+            const metadataVersion = 0;
+            const metadata = solidityPack(['uint32', 'bytes'], [metadataVersion, executablePayload.encode()]);
+
+            const tx = await evmItsContract.interchainTransfer(
+                hexlify(tokenId),
+                setup.solana.chainName,
+                solanaMemoProgram.programId.toBytes(),
+                Math.floor(transferAmount),
+                metadata,
+                gasValue,
+                { value: gasValue },
+            );
+
+            const srcGmpDetails = await utils.waitForGmpExecution(
+                tx.hash,
+                setup.axelar,
+            );
+            await utils.waitForGmpExecution(
+                srcGmpDetails.executed.transactionHash,
+                setup.axelar,
+            );
+
+            const currentBalance = Number(
+                (await setup.solana.connection.getTokenAccountBalance(
+                    memoAssociatedTokenAccount.address,
+                ))
+                    .value
+                    .amount,
+            );
+
+            expect(currentBalance).to.equal(transferAmount);
+        });
+    });
+});


### PR DESCRIPTION
This adds e2e tests for the main ITS flows (canonical and native interchain token deployments, custom token linking and interchain transfer - with and without contract call).

I had issues running parallel tests since same nonce was used by ethers in all tests. To solve that, I added a setup/teardown script that transfers funds to  separate wallets (one for each test) and then transfers back to the main EVM wallet in the end.